### PR TITLE
Fixed stream close() to end()

### DIFF
--- a/commands/generate.ts
+++ b/commands/generate.ts
@@ -189,5 +189,5 @@ ${commands.map(x => `  /** ${yaml[x].descr} */\n  ${writable(x)} = '${prefix}.${
 
 doc.write('\n')
 
-stream.close()
-doc.close()
+stream.end()
+doc.end()


### PR DESCRIPTION
Hey,

I could not compile your extension using 

```
vsce package
```
because
```
yarn run generate
```
already failed with
```
$ ts-node commands/generate.ts && ts-node package.ts                                                                                                                        

/home/geier/misc/dance/node_modules/ts-node/src/index.ts:245
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
package.ts:3:10 - error TS2724: Module '"./commands"' has no exported member 'commands'. Did you mean 'ICommand'?

3 import { commands } from './commands'
```

It turned out that `commands/index.ts` and `README.md` has not been generated completely.
Problem was that only the first `write(...)` was written because the `close()` at the end of the script happened to fast.

The solution was to use `end()` instead of `close()`: [nodejs/node/issues/5631](https://github.com/nodejs/node/issues/5631)

After this change I managed to create and use the extension.

---
I'm using kakoune heavily on Linux but have to switch to Windows for work... Just using vscodevim made me crazy, thank you for providing this extension :)