### PR TITLE
'fix' goto throwing null exception

### DIFF
--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -77,7 +77,9 @@ export function promptInList(canPickMany: boolean, items: [string, string][]): T
     })
 
     quickPick.onDidHide(() => {
-      const picked = quickPick.selectedItems
+      var picked = quickPick.selectedItems
+      if (picked !== undefined && picked.length === 0)
+        picked = quickPick.activeItems
 
       quickPick.dispose()
 


### PR DESCRIPTION
Hi,
just trying to check this extension out and couldn't use the goto commands because they simply wouldn't do anything. 

I know nothing about VS Code extensions, but it seems `selectedItems` was `length:0`, so I peaked into quickPick and saw that activeItems had the choosen command inside. 

Maybe that helps...