### PR TITLE
Feat save restore selections

### DIFF
--- a/src/commands/goto.ts
+++ b/src/commands/goto.ts
@@ -23,7 +23,7 @@ const jumps: [string, string][] = [
   ['.', 'go to last buffer modification position'],
 ]
 
-function executeGoto(gotoType: number, editor: vscode.TextEditor, extend: boolean) {
+function executeGoto(gotoType: number, editor: vscode.TextEditor, ctx: Extension, extend: boolean) {
   switch (gotoType) {
     case 0: // go to line start
       executeGotoLine(editor, extend, 'start')
@@ -89,6 +89,10 @@ function executeGoto(gotoType: number, editor: vscode.TextEditor, extend: boolea
       }))
 
     case 12: // go to last buffer modification position
+      let lastSel = ctx.history.for(editor.document).lastBufferModification
+      if(lastSel) {
+        editor.selections = [new vscode.Selection(lastSel.start, lastSel.start)]
+      }
       break
   }
 
@@ -163,7 +167,7 @@ function executeGotoLastLine(editor: vscode.TextEditor, extend: boolean, gotoLas
 }
 
 
-registerCommand(Command.goto, CommandFlags.ChangeSelections, InputKind.ListOneItemOrCount, jumps, (editor, state, _, __) => {
+registerCommand(Command.goto, CommandFlags.ChangeSelections, InputKind.ListOneItemOrCount, jumps, (editor, state, _, ctx) => {
   if (state.input === null) {
     let line = state.currentCount - 1
 
@@ -174,11 +178,11 @@ registerCommand(Command.goto, CommandFlags.ChangeSelections, InputKind.ListOneIt
 
     return
   } else {
-    return executeGoto(state.input, editor, false)
+    return executeGoto(state.input, editor, ctx, false)
   }
 })
 
-registerCommand(Command.gotoExtend, CommandFlags.ChangeSelections, InputKind.ListOneItemOrCount, jumps, (editor, state, _, __) => {
+registerCommand(Command.gotoExtend, CommandFlags.ChangeSelections, InputKind.ListOneItemOrCount, jumps, (editor, state, _, ctx) => {
   if (state.input === null) {
     let line = state.currentCount - 1
 
@@ -189,6 +193,6 @@ registerCommand(Command.gotoExtend, CommandFlags.ChangeSelections, InputKind.Lis
 
     return
   } else {
-    return executeGoto(state.input, editor, true)
+    return executeGoto(state.input, editor, ctx, true)
   }
 })

--- a/src/commands/insert.ts
+++ b/src/commands/insert.ts
@@ -3,15 +3,18 @@ import * as vscode from 'vscode'
 import { registerCommand, Command, CommandFlags, CommandDescriptor, Mode } from '.'
 
 
-registerCommand(Command.insertBefore, CommandFlags.ChangeSelections | CommandFlags.SwitchToInsert, editor => {
+registerCommand(Command.insertBefore, CommandFlags.ChangeSelections | CommandFlags.SwitchToInsert, (editor, _, __, ctx) => {
+  ctx.prepareInsertion(editor, 'before')
   editor.selections = editor.selections.map(x => new vscode.Selection(x.start, x.start))
 })
 
-registerCommand(Command.insertAfter, CommandFlags.ChangeSelections | CommandFlags.SwitchToInsert, editor => {
+registerCommand(Command.insertAfter, CommandFlags.ChangeSelections | CommandFlags.SwitchToInsert, (editor, _, __, ctx) => {
+  ctx.prepareInsertion(editor, 'after')
   editor.selections = editor.selections.map(x => new vscode.Selection(x.end, x.end))
 })
 
-registerCommand(Command.insertLineStart, CommandFlags.ChangeSelections | CommandFlags.SwitchToInsert, editor => {
+registerCommand(Command.insertLineStart, CommandFlags.ChangeSelections | CommandFlags.SwitchToInsert, (editor, _, __, ctx) => {
+  ctx.prepareInsertion(editor, 'start')
   editor.selections = editor.selections.map(x => {
     const anchor = editor.document.lineAt(x.active.line).range.start
 
@@ -19,7 +22,8 @@ registerCommand(Command.insertLineStart, CommandFlags.ChangeSelections | Command
   })
 })
 
-registerCommand(Command.insertLineEnd, CommandFlags.ChangeSelections | CommandFlags.SwitchToInsert, editor => {
+registerCommand(Command.insertLineEnd, CommandFlags.ChangeSelections | CommandFlags.SwitchToInsert, (editor, _, __, ctx) => {
+  ctx.prepareInsertion(editor, 'end')
   editor.selections = editor.selections.map(x => {
     const anchor = editor.document.lineAt(x.active.line).range.end
 
@@ -27,11 +31,13 @@ registerCommand(Command.insertLineEnd, CommandFlags.ChangeSelections | CommandFl
   })
 })
 
-registerCommand(Command.insertNewLineAbove, CommandFlags.Edit | CommandFlags.SwitchToInsert, () => {
+registerCommand(Command.insertNewLineAbove, CommandFlags.Edit | CommandFlags.SwitchToInsert, (editor, _, __, ctx) => {
+  ctx.prepareInsertion(editor, 'above')
   return vscode.commands.executeCommand('editor.action.insertLineBefore')
 })
 
-registerCommand(Command.insertNewLineBelow, CommandFlags.Edit | CommandFlags.SwitchToInsert, () => {
+registerCommand(Command.insertNewLineBelow, CommandFlags.Edit | CommandFlags.SwitchToInsert, (editor, _, __, ctx) => {
+  ctx.prepareInsertion(editor, 'below')
   return vscode.commands.executeCommand('editor.action.insertLineAfter')
 })
 

--- a/src/commands/mark.ts
+++ b/src/commands/mark.ts
@@ -34,13 +34,15 @@ const combineOpts = [
 
 // }
 
-// registerCommand(Command.marksSaveSelections, async (editor, state) => {
-//   const register = state.currentRegister || state.registers.caret
-// })
+registerCommand(Command.marksSaveSelections, CommandFlags.IgnoreInHistory, async (editor, state, _, ctx) => {
+  const register = ctx.currentRegister || ctx.registers.caret
+  ctx.history.for(editor.document).setSelectionsForMark(editor.document, register, editor.selections)
+})
 
-// registerCommand(Command.marksRestoreSelections, async (editor, state) => {
-//   const register = state.currentRegister || state.registers.caret
-// })
+registerCommand(Command.marksRestoreSelections, CommandFlags.IgnoreInHistory, async (editor, state, _, ctx) => {
+  const register = ctx.currentRegister || ctx.registers.caret
+  editor.selections = ctx.history.for(editor.document).getSelectionsForMark(editor.document,register)
+})
 
 // registerCommand(Command.marksCombineSelectionsFromCurrent, async (editor, state) => {
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode'
 
-import { commands, Mode }      from './commands/index'
-import { HistoryManager }      from './history'
+import { commands, Mode } from './commands/index'
+import { HistoryManager } from './history'
 import { Register, Registers } from './registers'
-import { OffsetEdgeTransformationBehaviour }      from './utils/offsetSelection'
+import { OffsetEdgeTransformationBehaviour } from './utils/offsetSelection'
 
 
 /** Name of the extension, used in commands and settings. */
@@ -169,18 +169,19 @@ export class Extension implements vscode.Disposable {
   readonly history   = new HistoryManager()
 
   readonly selectionDecorationType = vscode.window.createTextEditorDecorationType(
-    <vscode.DecorationRenderOptions> {
-      color:  { id: "editor.foreground" },
-      backgroundColor:  { id: "editor.selectionBackground" }
+    {
+      color: { id: 'editor.foreground' },
+      backgroundColor: { id: 'editor.selectionBackground' }
     }
   )
   
   readonly selectionInsertDecorationType = vscode.window.createTextEditorDecorationType(
-    <vscode.DecorationRenderOptions> {
-      color:  { id: "editor.foreground" },
-      backgroundColor:  { id: "editor.background" }
+    {
+      color: { id: 'editor.foreground' },
+      backgroundColor: { id: 'editor.background' }
     }
   )
+  
   readonly insertMode = ModeConfiguration.insert()
   readonly normalMode = ModeConfiguration.normal()
 
@@ -259,7 +260,7 @@ export class Extension implements vscode.Disposable {
   restoreLastSelections(editor: vscode.TextEditor) {
     let documentHistory = this.history.for(editor.document)
     let lastSels = documentHistory.getLastSelections(editor.document)
-    if (lastSels.length > 0 ) {
+    if (lastSels.length > 0) {
       editor.selections = lastSels
     }
   }
@@ -437,25 +438,25 @@ export class Extension implements vscode.Disposable {
             let reset = true
             //! If selection kind is Command it should/can be produced by insertion/append from dance
             //! If selection kind is Keyboard it should/can be produced by textchanges
-            if(!!e.kind && ((e.kind === vscode.TextEditorSelectionChangeKind.Command) || (e.kind === vscode.TextEditorSelectionChangeKind.Keyboard))) {
+            if (!!e.kind && ((e.kind === vscode.TextEditorSelectionChangeKind.Command) || (e.kind === vscode.TextEditorSelectionChangeKind.Keyboard))) {
               //! Luckily document changes are fired before selection changes,
               //! hence the 'last selections' in the document history has been already updated.
               //! If new selections intersect with last selections of document changes, 
               //! it is assumed that the last selection must not be reset.
               let documentHistory = this.history.for(e.textEditor.document)
               let lastSels = documentHistory.getLastSelections(e.textEditor.document)
-              if(lastSels.length === e.selections.length) {
+              if (lastSels.length === e.selections.length) {
                 reset = false
                 for (let index in e.selections) {
-                  let intersection = lastSels[index].intersection(e.selections[index])
-                  if(lastSels[index].intersection(e.selections[index]) === undefined) {
+                  const intersection = lastSels[index].intersection(e.selections[index])
+                  if (lastSels[index].intersection(e.selections[index]) === undefined) {
                     reset = true
                     continue
                   }
                 }
               } 
             }
-            if(reset) {
+            if (reset) {
               this.resetLastSelections(e.textEditor)
             }
           } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -230,7 +230,7 @@ export class Extension implements vscode.Disposable {
     if (pos === 'before' || pos === 'after' ) {
       this.history.for(editor.document).setLastSelections(editor.document, editor.selections, (pos === 'before' ? OffsetEdgeTransformationBehaviour.ExclusiveStart : OffsetEdgeTransformationBehaviour.Inclusive))
       editor.setDecorations(this.selectionDecorationType, editor.selections.map( sel => new vscode.Range( sel.start, sel.end) ))
-      //! And an overlay to normalize inserted text -- reproduces kakoune behaviour
+      // And an overlay to normalize inserted text -- reproduces kakoune behaviour
       if (pos === 'before') {
         editor.setDecorations(this.selectionInsertDecorationType, editor.selections.map( sel => new vscode.Range( sel.start, sel.start) ))
       }
@@ -258,8 +258,8 @@ export class Extension implements vscode.Disposable {
   }
 
   restoreLastSelections(editor: vscode.TextEditor) {
-    let documentHistory = this.history.for(editor.document)
-    let lastSels = documentHistory.getLastSelections(editor.document)
+    const documentHistory = this.history.for(editor.document)
+    const lastSels = documentHistory.getLastSelections(editor.document)
     if (lastSels.length > 0) {
       editor.selections = lastSels
     }
@@ -436,15 +436,15 @@ export class Extension implements vscode.Disposable {
           if (mode === Mode.Insert) {
             this.setDecorations(e.textEditor, this.insertMode.decorationType)
             let reset = true
-            //! If selection kind is Command it should/can be produced by insertion/append from dance
-            //! If selection kind is Keyboard it should/can be produced by textchanges
+            // If selection kind is Command it should/can be produced by insertion/append from dance
+            // If selection kind is Keyboard it should/can be produced by textchanges
             if (!!e.kind && ((e.kind === vscode.TextEditorSelectionChangeKind.Command) || (e.kind === vscode.TextEditorSelectionChangeKind.Keyboard))) {
-              //! Luckily document changes are fired before selection changes,
-              //! hence the 'last selections' in the document history has been already updated.
-              //! If new selections intersect with last selections of document changes, 
-              //! it is assumed that the last selection must not be reset.
-              let documentHistory = this.history.for(e.textEditor.document)
-              let lastSels = documentHistory.getLastSelections(e.textEditor.document)
+              // Luckily document changes are fired before selection changes,
+              // hence the 'last selections' in the document history has been already updated.
+              // If new selections intersect with last selections of document changes, 
+              // it is assumed that the last selection must not be reset.
+              const documentHistory = this.history.for(e.textEditor.document)
+              const lastSels = documentHistory.getLastSelections(e.textEditor.document)
               if (lastSels.length === e.selections.length) {
                 reset = false
                 for (let index in e.selections) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -435,8 +435,6 @@ export class Extension implements vscode.Disposable {
           if (mode === Mode.Insert) {
             this.setDecorations(e.textEditor, this.insertMode.decorationType)
             let reset = true
-            console.log("SelectionKind: ", e.kind)
-            //if(!!e.kind && (e.kind == vscode.TextEditorSelectionChangeKind.Keyboard)) {
             //! If selection kind is Command it should/can be produced by insertion/append from dance
             //! If selection kind is Keyboard it should/can be produced by textchanges
             if(!!e.kind && ((e.kind == vscode.TextEditorSelectionChangeKind.Command) || (e.kind == vscode.TextEditorSelectionChangeKind.Keyboard))) {
@@ -446,15 +444,10 @@ export class Extension implements vscode.Disposable {
               //! it is assumed that the last selection must not be reset.
               let documentHistory = this.history.for(e.textEditor.document)
               let lastSels = documentHistory.getLastSelections(e.textEditor.document)
-              console.log(`Selection Length: ${e.selections.length} LastSel Length: ${lastSels.length}`)
               if(lastSels.length == e.selections.length) {
                 reset = false
                 for (let index in e.selections) {
-                  console.log("Index: ", index)
-                  console.log("LastSel: ", lastSels[index])
-                  console.log("NewSel: ", e.selections[index])
                   let intersection = lastSels[index].intersection(e.selections[index])
-                  console.log("Intersection: ", intersection)
                   if(lastSels[index].intersection(e.selections[index]) === undefined) {
                     reset = true
                     continue
@@ -465,8 +458,6 @@ export class Extension implements vscode.Disposable {
             if(reset) {
               this.resetLastSelections(e.textEditor)
             }
-           
-            console.log("SelectionChange")
           } else {
             this.setDecorations(e.textEditor, this.normalMode.decorationType)
           }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,8 +34,8 @@ export class Extension implements vscode.Disposable {
 
   readonly selectionDecorationType = vscode.window.createTextEditorDecorationType(
     <vscode.DecorationRenderOptions> {
-      color:  {id: "editor.foreground" },
-      backgroundColor:  {id: "editor.selectionBackground" }
+      color:  { id: "editor.foreground" },
+      backgroundColor:  { id: "editor.selectionBackground" }
     }
   )
 
@@ -112,7 +112,7 @@ export class Extension implements vscode.Disposable {
       //! Restore selections
       let documentHistory = this.history.for(editor.document)
       let lastSels = documentHistory.getLastSelections(editor.document)
-      if(lastSels.length > 0 ) {
+      if (lastSels.length > 0 ) {
         editor.selections = lastSels
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -226,11 +226,11 @@ export class Extension implements vscode.Disposable {
   }
 
   prepareInsertion(editor: vscode.TextEditor, pos: 'before' | 'after' | 'start' | 'end' | 'above' | 'below') {
-    if (pos == 'before' || pos == 'after' ) {
-      this.history.for(editor.document).setLastSelections(editor.document, editor.selections, (pos == 'before' ? OffsetEdgeTransformationBehaviour.ExclusiveStart : OffsetEdgeTransformationBehaviour.Inclusive))
+    if (pos === 'before' || pos === 'after' ) {
+      this.history.for(editor.document).setLastSelections(editor.document, editor.selections, (pos === 'before' ? OffsetEdgeTransformationBehaviour.ExclusiveStart : OffsetEdgeTransformationBehaviour.Inclusive))
       editor.setDecorations(this.selectionDecorationType, editor.selections.map( sel => new vscode.Range( sel.start, sel.end) ))
       //! And an overlay to normalize inserted text -- reproduces kakoune behaviour
-      if (pos == 'before') {
+      if (pos === 'before') {
         editor.setDecorations(this.selectionInsertDecorationType, editor.selections.map( sel => new vscode.Range( sel.start, sel.start) ))
       }
     } else {
@@ -437,14 +437,14 @@ export class Extension implements vscode.Disposable {
             let reset = true
             //! If selection kind is Command it should/can be produced by insertion/append from dance
             //! If selection kind is Keyboard it should/can be produced by textchanges
-            if(!!e.kind && ((e.kind == vscode.TextEditorSelectionChangeKind.Command) || (e.kind == vscode.TextEditorSelectionChangeKind.Keyboard))) {
+            if(!!e.kind && ((e.kind === vscode.TextEditorSelectionChangeKind.Command) || (e.kind === vscode.TextEditorSelectionChangeKind.Keyboard))) {
               //! Luckily document changes are fired before selection changes,
               //! hence the 'last selections' in the document history has been already updated.
               //! If new selections intersect with last selections of document changes, 
               //! it is assumed that the last selection must not be reset.
               let documentHistory = this.history.for(e.textEditor.document)
               let lastSels = documentHistory.getLastSelections(e.textEditor.document)
-              if(lastSels.length == e.selections.length) {
+              if(lastSels.length === e.selections.length) {
                 reset = false
                 for (let index in e.selections) {
                   let intersection = lastSels[index].intersection(e.selections[index])

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 
 import { CommandDescriptor, CommandState, InputKind } from './commands'
-import { OffsetRange, OffsetSelection } from './utils/offsetSelection'
+import { OffsetRange, OffsetSelection, OffsetEdgeTransformationBehaviour } from './utils/offsetSelection'
 import { Register } from './registers'
 
 
@@ -142,8 +142,8 @@ export class DocumentHistory {
     return this.changes.get(commandState) || [] as readonly vscode.TextDocumentContentChangeEvent[]
   }
 
-  setLastSelections(document: vscode.TextDocument, newSelections: vscode.Selection[]) {
-    this.lastSelections = newSelections.map( sel => new OffsetSelection(document.offsetAt(sel.anchor), document.offsetAt(sel.active)))
+  setLastSelections(document: vscode.TextDocument, newSelections: vscode.Selection[], transformationBehaviour: OffsetEdgeTransformationBehaviour = OffsetEdgeTransformationBehaviour.ExclusiveStart) {
+    this.lastSelections = newSelections.map( sel => new OffsetSelection(document.offsetAt(sel.anchor), document.offsetAt(sel.active), transformationBehaviour))
   }
 
   getLastSelections(document: vscode.TextDocument): vscode.Selection[] {

--- a/src/history.ts
+++ b/src/history.ts
@@ -48,10 +48,10 @@ export class DocumentHistory {
   lastBufferModification = undefined as vscode.Range | undefined
 
   private prepareChanges(changes: vscode.TextDocumentContentChangeEvent[]) {
-    let prepChanges = changes.slice() // Copy arry with slice
+    const prepChanges = changes.slice() // Copy arry with slice
       .sort((c1, c2) => c1.range.start.compareTo(c2.range.start))
       .map(c => {
-          let offRange = new OffsetRange(c.rangeOffset, c.rangeOffset + c.rangeLength)
+          const offRange = new OffsetRange(c.rangeOffset, c.rangeOffset + c.rangeLength)
           return <PreparedChanges> {
             initialRemoveRange: offRange,
             remove: offRange,
@@ -95,8 +95,8 @@ export class DocumentHistory {
 
       const filteredChanges = changes.filter(c => s.intersects(c.initialRemoveRange))
       
-      //! Apply all changes
-      //! The changes are ordered and hence already should have the right precomputed offset
+      // Apply all changes
+      // The changes are ordered and hence already should have the right precomputed offset
       if (filteredChanges.length > 0) {
         let newSel: OffsetSelection | undefined = s.translateSelection(filteredChanges[0].absOffsetChangeBefore)
         for (let i = 0; i < filteredChanges.length; ++i) {
@@ -115,7 +115,7 @@ export class DocumentHistory {
     // Handle marks and selections
     if (changes.length > 0) {
       this.lastBufferModification = changes[0].range
-      let changesAccum = this.prepareChanges(changes)
+      const changesAccum = this.prepareChanges(changes)
       this.lastSelections = this.updateChanges(this.lastSelections, changesAccum)
       this.marks.forEach(
         (sels, register: Register, map) => map.set(register, this.updateChanges(sels, changesAccum))

--- a/src/history.ts
+++ b/src/history.ts
@@ -87,20 +87,20 @@ export class DocumentHistory {
    */
   private updateChanges(offsetSelections: OffsetSelection[], changes: PreparedChanges[]) {
     return offsetSelections.map( s => {
-      if(changes.length == 0) return s
+      if (changes.length == 0) return s
       // If current selection is before all changes...
-      if(s.end < changes[0].initialRemoveRange.start) return s
+      if (s.end < changes[0].initialRemoveRange.start) return s
       // If current selection is after all changes...
-      if(s.start > changes[changes.length - 1].initialRemoveRange.end) return s.translateSelection(changes[changes.length - 1].absOffsetChange)
+      if (s.start > changes[changes.length - 1].initialRemoveRange.end) return s.translateSelection(changes[changes.length - 1].absOffsetChange)
 
       let filteredChanges = changes.filter( c => s.intersects(c.initialRemoveRange))
       //! Apply all changes
       //! The changes are ordered and hence already should have the right precomputed offset
-      if(filteredChanges.length > 0) {
+      if (filteredChanges.length > 0) {
         let newSel: OffsetSelection | undefined = s.translateSelection(filteredChanges[0].absOffsetChangeBefore)
         for(let i = 0; i < filteredChanges.length; ++i) {
           newSel = newSel.removeAndInsert(filteredChanges[i].remove, filteredChanges[i].insert)
-          if(newSel === undefined) {
+          if (newSel === undefined) {
             return undefined
           }
         }
@@ -112,7 +112,7 @@ export class DocumentHistory {
 
   handleChanges(changes: vscode.TextDocumentContentChangeEvent[]) {
     // Handle marks and selections
-    if(changes.length > 0) {
+    if (changes.length > 0) {
       this.lastBufferModification = changes[0].range
       let changesAccum = this.prepareChanges(changes)
       this.lastSelections = this.updateChanges(this.lastSelections, changesAccum)
@@ -156,7 +156,7 @@ export class DocumentHistory {
 
   getSelectionsForMark(document: vscode.TextDocument, register: Register) {
     let offSel = this.marks.get(register)
-    if(offSel) {
+    if (offSel) {
       return offSel.map( offsetSel => offsetSel.toVSCodeSelection(document))
     }
     return [] as vscode.Selection[]

--- a/src/history.ts
+++ b/src/history.ts
@@ -13,6 +13,7 @@ export class HistoryManager {
 
   constructor() {
     this.changeDisposable = vscode.workspace.onDidChangeTextDocument(change => {
+      console.log("Change: ", change)
       this.for(change.document).handleChanges(change.contentChanges)
     })
   }
@@ -48,7 +49,7 @@ export class DocumentHistory {
   lastBufferModification = undefined as vscode.Range | undefined
 
   private prepareChanges(changes: vscode.TextDocumentContentChangeEvent[]) {
-    let prepChanges = changes
+    let prepChanges = changes.slice() // Copy arry with slice
       .sort( (c1, c2) => c1.range.start.compareTo(c2.range.start) )
       .map( (c) => {
           let offRange = new OffsetRange(c.rangeOffset, c.rangeOffset + c.rangeLength)
@@ -112,10 +113,12 @@ export class DocumentHistory {
 
   handleChanges(changes: vscode.TextDocumentContentChangeEvent[]) {
     // Handle marks and selections
+    console.log("handleChanges: ", changes)
     if (changes.length > 0) {
       this.lastBufferModification = changes[0].range
       let changesAccum = this.prepareChanges(changes)
       this.lastSelections = this.updateChanges(this.lastSelections, changesAccum)
+      console.log("lastSelections After Change: ", this.lastSelections)
       this.marks.forEach(
         (sels, register: Register, map) => map.set(register, this.updateChanges(sels, changesAccum))
       )

--- a/src/history.ts
+++ b/src/history.ts
@@ -87,7 +87,7 @@ export class DocumentHistory {
    */
   private updateChanges(offsetSelections: OffsetSelection[], changes: PreparedChanges[]) {
     return offsetSelections.map( s => {
-      if (changes.length == 0) return s
+      if (changes.length === 0) return s
       // If current selection is before all changes...
       if (s.end < changes[0].initialRemoveRange.start) return s
       // If current selection is after all changes...

--- a/src/history.ts
+++ b/src/history.ts
@@ -13,7 +13,6 @@ export class HistoryManager {
 
   constructor() {
     this.changeDisposable = vscode.workspace.onDidChangeTextDocument(change => {
-      console.log("Change: ", change)
       this.for(change.document).handleChanges(change.contentChanges)
     })
   }
@@ -113,12 +112,10 @@ export class DocumentHistory {
 
   handleChanges(changes: vscode.TextDocumentContentChangeEvent[]) {
     // Handle marks and selections
-    console.log("handleChanges: ", changes)
     if (changes.length > 0) {
       this.lastBufferModification = changes[0].range
       let changesAccum = this.prepareChanges(changes)
       this.lastSelections = this.updateChanges(this.lastSelections, changesAccum)
-      console.log("lastSelections After Change: ", this.lastSelections)
       this.marks.forEach(
         (sels, register: Register, map) => map.set(register, this.updateChanges(sels, changesAccum))
       )

--- a/src/utils/offsetSelection.ts
+++ b/src/utils/offsetSelection.ts
@@ -221,7 +221,7 @@ export class OffsetSelection extends OffsetRange {
                             ? (other.length - (int ? int.length : 0))
                             : 0)
         const shiftAfter  = (int ? int.length : 0)
-        return this.shiftSelectionByPositions({ start: shiftBefore * -1, end: (shiftBefore+shiftAfter) * -1})
+        return this.shiftSelectionByPositions({start: shiftBefore * -1, end: (shiftBefore+shiftAfter) * -1})
       }
     }
     

--- a/src/utils/offsetSelection.ts
+++ b/src/utils/offsetSelection.ts
@@ -51,11 +51,11 @@ export class  OffsetRange {
     }
 
     shiftEnd(delta: number) {
-      return this.shift({start: 0, end: delta})
+      return this.shift({ start: 0, end: delta})
     }
 
     shiftStart(delta: number) {
-      return this.shift({start: delta, end: 0})
+      return this.shift({ start: delta, end: 0})
     }
 
     contains(other: OffsetRange) {
@@ -209,7 +209,7 @@ export class OffsetSelection extends OffsetRange {
                             ? (other.length - (int ? int.length : 0))
                             : 0)
         let shiftAfter  = (int ? int.length : 0)
-        return this.shiftSelectionByPositions({start: shiftBefore * -1, end: (shiftBefore+shiftAfter) * -1})
+        return this.shiftSelectionByPositions({ start: shiftBefore * -1, end: (shiftBefore+shiftAfter) * -1})
       }
     }
 

--- a/src/utils/offsetSelection.ts
+++ b/src/utils/offsetSelection.ts
@@ -20,7 +20,7 @@ export class  OffsetRange {
     readonly isEmpty: boolean
 
     constructor(start: number, end: number) {
-      if(start < end) {
+      if (start < end) {
         this.start = start
         this.end   = end
       } else {
@@ -32,7 +32,7 @@ export class  OffsetRange {
     }
 
     translate(delta: number) {
-      if(delta === 0) {
+      if (delta === 0) {
         return this
       } else {
         return new OffsetRange(
@@ -43,7 +43,7 @@ export class  OffsetRange {
     }
 
     shift(delta: DeltaByPosition) {
-      if(delta.start === 0 && delta.end === 0) {
+      if (delta.start === 0 && delta.end === 0) {
         return this
       } else {
         return new OffsetRange(
@@ -77,7 +77,7 @@ export class  OffsetRange {
     }
 
     intersection(other: OffsetRange): OffsetRange | undefined {
-      if(this.intersects(other)) {
+      if (this.intersects(other)) {
         return new OffsetRange(Math.max(this.start, other.start), Math.min(this.end, other.end))
       }
       return undefined
@@ -116,7 +116,7 @@ export class OffsetSelection extends OffsetRange {
     }
 
     translateSelection(delta: number) {
-      if(delta === 0) {
+      if (delta === 0) {
         return this
       } else {
         return new OffsetSelection(
@@ -129,7 +129,7 @@ export class OffsetSelection extends OffsetRange {
 
 
     shiftSelectionByAnchors(delta: DeltaByAnchor): OffsetSelection {
-      if(delta.anchor === 0 && delta.active === 0) {
+      if (delta.anchor === 0 && delta.active === 0) {
         return this
       } else {
         return new OffsetSelection(
@@ -140,7 +140,7 @@ export class OffsetSelection extends OffsetRange {
     }
 
     shiftSelectionByPositions(delta: DeltaByPosition): OffsetSelection {
-      if(delta.start === 0 && delta.end === 0) {
+      if (delta.start === 0 && delta.end === 0) {
         return this
       } else {
         return (this.isReversed
@@ -157,7 +157,7 @@ export class OffsetSelection extends OffsetRange {
     }
 
     shiftSelection(delta: DeltaByAnchor | DeltaByPosition) {
-      if(delta as DeltaByAnchor) {
+      if (delta as DeltaByAnchor) {
         return this.shiftSelectionByAnchors(<DeltaByAnchor>delta)
       } else {
         return this.shiftSelectionByPositions(<DeltaByPosition>delta)
@@ -165,7 +165,7 @@ export class OffsetSelection extends OffsetRange {
     }
 
     shiftActive(delta: number) {
-      if(delta === 0) {
+      if (delta === 0) {
         return this
       } else {
         return new OffsetSelection(
@@ -176,7 +176,7 @@ export class OffsetSelection extends OffsetRange {
     }
 
     shiftAnchor(delta: number) {
-      if(delta === 0) {
+      if (delta === 0) {
         return this
       } else {
         return new OffsetSelection(
@@ -209,18 +209,18 @@ export class OffsetSelection extends OffsetRange {
     }
 
     remove(other: OffsetRange): OffsetSelection | undefined {
-      if(other.isEmpty) {
+      if (other.isEmpty) {
         return this
       }
-      if(other.contains(this)) {
+      if (other.contains(this)) {
         return undefined
       }
       else {
-        let int = this.intersection(other)
-        let shiftBefore = (other.start <= this.start
+        const int = this.intersection(other)
+        const shiftBefore = (other.start <= this.start
                             ? (other.length - (int ? int.length : 0))
                             : 0)
-        let shiftAfter  = (int ? int.length : 0)
+        const shiftAfter  = (int ? int.length : 0)
         return this.shiftSelectionByPositions({ start: shiftBefore * -1, end: (shiftBefore+shiftAfter) * -1})
       }
     }
@@ -234,11 +234,12 @@ export class OffsetSelection extends OffsetRange {
     }
 
     insert(offset: number, length: number, transformationBehaviour: OffsetEdgeTransformationBehaviour | undefined = OffsetEdgeTransformationBehaviour.ExclusiveStart): OffsetSelection {
-      if(transformationBehaviour === undefined) transformationBehaviour = this.transformationBehaviour 
-      if( (transformationBehaviour & OffsetEdgeTransformationBehaviour.ExclusiveEnd) ? offset >= this.end : offset > this.end) {
+      if (transformationBehaviour === undefined) transformationBehaviour = this.transformationBehaviour
+      
+      if ((transformationBehaviour & OffsetEdgeTransformationBehaviour.ExclusiveEnd) ? offset >= this.end : offset > this.end) {
         return this
       }
-      else if( (transformationBehaviour & OffsetEdgeTransformationBehaviour.ExclusiveStart) ? offset <= this.start : offset < this.start) {
+      else if ( (transformationBehaviour & OffsetEdgeTransformationBehaviour.ExclusiveStart) ? offset <= this.start : offset < this.start) {
         return this.translateSelection(length)
       } else {
         return this.shiftSelectionEnd(length)
@@ -246,9 +247,10 @@ export class OffsetSelection extends OffsetRange {
     }
 
     removeAndInsert(other: OffsetRange, length: number, transformationBehaviour: OffsetEdgeTransformationBehaviour | undefined = OffsetEdgeTransformationBehaviour.ExclusiveStart): OffsetSelection | undefined {
-      if(transformationBehaviour === undefined) transformationBehaviour = this.transformationBehaviour 
-      let removeMaybe = this.remove(other)
-      if(removeMaybe) {
+      if (transformationBehaviour === undefined) transformationBehaviour = this.transformationBehaviour
+      
+      const removeMaybe = this.remove(other)
+      if (removeMaybe) {
         return removeMaybe.insert(other.start, length, transformationBehaviour)
       }
       return undefined

--- a/src/utils/offsetSelection.ts
+++ b/src/utils/offsetSelection.ts
@@ -1,0 +1,241 @@
+import * as vscode from 'vscode'
+
+interface DeltaByAnchor {
+  anchor: number
+  active: number
+}
+
+interface DeltaByPosition {
+  start: number
+  end: number
+}
+
+export class  OffsetRange {
+    readonly start: number
+    readonly end: number
+    readonly length: number
+    readonly isEmpty: boolean
+
+    constructor(start: number, end: number) {
+      if(start < end) {
+        this.start = start
+        this.end   = end
+      } else {
+        this.start = end
+        this.end   = start
+      }
+      this.length = this.end - this.start
+      this.isEmpty = (start === end)
+    }
+
+    translate(delta: number) {
+      if(delta === 0) {
+        return this
+      } else {
+        return new OffsetRange(
+                    this.start + delta,
+                    this.end + delta
+                   )
+      }
+    }
+
+    shift(delta: DeltaByPosition) {
+      if(delta.start === 0 && delta.end === 0) {
+        return this
+      } else {
+        return new OffsetRange(
+                    this.start + delta.start,
+                    this.end + delta.end
+                   )
+      }
+    }
+
+    shiftEnd(delta: number) {
+      return this.shift({start: 0, end: delta})
+    }
+
+    shiftStart(delta: number) {
+      return this.shift({start: delta, end: 0})
+    }
+
+    contains(other: OffsetRange) {
+      return ((this.start <= other.start) && (this.end >= other.end))
+    }
+
+    union(other: OffsetRange) {
+      return new OffsetRange(Math.min(this.start, other.start), Math.max(this.end, other.end))
+    }
+
+    intersects(other: OffsetRange) {
+      return (
+         (this.start  <= other.start && this.end  >= other.start) ||
+         (other.start <= this.start  && other.end >= this.start)
+        ) 
+    }
+
+    intersection(other: OffsetRange): OffsetRange | undefined {
+      if(this.intersects(other)) {
+        return new OffsetRange(Math.max(this.start, other.start), Math.min(this.end, other.end))
+      }
+      return undefined
+    }
+
+    isEqual(other: OffsetRange) {
+      return (this.start === other.start && this.end === other.end)
+    }
+
+    toString() {
+      return `<OffsetRange>[${this.start}, ${this.end}]`
+    }
+}
+
+export class OffsetSelection extends OffsetRange {
+    anchor: number
+    active: number
+    readonly isReversed: boolean
+    readonly isEmpty: boolean
+
+    constructor(anchor: number, active: number) {
+      super(anchor, active)
+      this.anchor = anchor
+      this.active = active
+      this.isReversed = (active < anchor)
+      this.isEmpty = (active === anchor)
+    }
+
+    translateSelection(delta: number) {
+      if(delta === 0) {
+        return this
+      } else {
+        return new OffsetSelection(
+                    this.anchor + delta,
+                    this.active + delta
+                   )
+      }
+    }
+
+
+
+    shiftSelectionByAnchors(delta: DeltaByAnchor): OffsetSelection {
+      if(delta.anchor === 0 && delta.active === 0) {
+        return this
+      } else {
+        return new OffsetSelection(
+                    this.anchor + delta.anchor,
+                    this.active + delta.active
+                   )
+      }
+    }
+
+    shiftSelectionByPositions(delta: DeltaByPosition): OffsetSelection {
+      if(delta.start === 0 && delta.end === 0) {
+        return this
+      } else {
+        return (this.isReversed
+                ? new OffsetSelection(
+                      this.active + delta.start,
+                      this.anchor + delta.end,
+                     )
+                : new OffsetSelection(
+                      this.anchor + delta.start,
+                      this.active + delta.end
+                     )
+        )
+      }
+    }
+
+    shiftSelection(delta: DeltaByAnchor | DeltaByPosition) {
+      if(delta as DeltaByAnchor) {
+        return this.shiftSelectionByAnchors(<DeltaByAnchor>delta)
+      } else {
+        return this.shiftSelectionByPositions(<DeltaByPosition>delta)
+      }
+    }
+
+    shiftActive(delta: number) {
+      if(delta === 0) {
+        return this
+      } else {
+        return new OffsetSelection(
+                    this.anchor,
+                    this.active + delta
+                   )
+      }
+    }
+
+    shiftAnchor(delta: number) {
+      if(delta === 0) {
+        return this
+      } else {
+        return new OffsetSelection(
+                    this.anchor + delta,
+                    this.active
+                   )
+      }
+    }
+
+    shiftSelectionEnd(delta: number) {
+      return ( this.isReversed
+        ? this.shiftAnchor(delta)
+        : this.shiftActive(delta)
+      )
+    }
+
+    shiftSelectionStart(delta: number) {
+      return ( this.isReversed
+        ? this.shiftActive(delta)
+        : this.shiftAnchor(delta)
+      )
+    }
+
+    isEqual(other: OffsetSelection) {
+      return (this.anchor === other.anchor && this.active === other.active)
+    }
+
+    toVSCodeSelection(document: vscode.TextDocument) {
+      return new vscode.Selection(document.positionAt(this.anchor), document.positionAt(this.active))
+    }
+
+    remove(other: OffsetRange): OffsetSelection | undefined {
+      if(other.isEmpty) {
+        return this
+      }
+      if(other.contains(this)) {
+        return undefined
+      }
+      else {
+        let int = this.intersection(other)
+        let shiftBefore = (other.start <= this.start
+                            ? (other.length - (int ? int.length : 0))
+                            : 0)
+        let shiftAfter  = (int ? int.length : 0)
+        return this.shiftSelectionByPositions({start: shiftBefore * -1, end: (shiftBefore+shiftAfter) * -1})
+      }
+    }
+
+    insert(offset: number, length: number): OffsetSelection {
+      //! This behaviour changes whether changes at the start/end of a selections are inclusive or exclusive.
+      //if(offset >= this.end || (length <= 0))
+      if(offset > this.end || (length <= 0)) {
+        return this
+      }
+      //else if(offset <= this.start)
+      else if(offset < this.start) {
+        return this.translateSelection(length)
+      } else {
+        return this.shiftSelectionEnd(length)
+      }
+    }
+
+    removeAndInsert(other: OffsetRange, length: number): OffsetSelection | undefined {
+      let removeMaybe = this.remove(other)
+      if(removeMaybe) {
+        return removeMaybe.insert(other.start, length)
+      }
+      return undefined
+    }
+
+    toString() {
+      return `<OffsetSelection>{ anchor: ${this.anchor}, active: ${this.active}}`
+    }
+}


### PR DESCRIPTION
Hey,

I noticed that you made the extension available finally. So I thought it is time to incorporate my efforts on saving and restoring selections. (The code was lounging around for some months...)

This feature also implements a kakoune-like behaviour: When switching to insert mode, selections are maintained (made visual using decorators) and restored when switching back to normal mode. So the user won't see a difference.