### PR TITLE
Add dance.selections.allowEmpty configuration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,11 @@
           ],
           "default": "inherit",
           "description": "Controls the cursor style in insert mode."
+        },
+        "dance.selections.allowEmpty": {
+          "type": "boolean",
+          "default": true,
+          "description": "Controls whether selections can be empty. If false, each selection will have at least one character."
         }
       }
     },

--- a/package.ts
+++ b/package.ts
@@ -105,6 +105,11 @@ const pkg = {
           default: 'inherit',
           description: 'Controls the cursor style in insert mode.',
         },
+        'dance.selections.allowEmpty': {
+          type: 'boolean',
+          default: true,
+          description: 'Controls whether selections can be empty. If false, each selection will have at least one character.',
+        },
       },
     },
     commands: Object.values(commands).map(x => ({

--- a/src/commands/changes.ts
+++ b/src/commands/changes.ts
@@ -17,10 +17,11 @@ function deleteSelection(builder: vscode.TextEditorEdit, editor: vscode.TextEdit
 
   const line = editor.document.lineAt(selection.active.line)
 
-  if (!line.range.isEmpty)
-    return builder.delete(selection)
+  // Delete the line break if selection is at end of line.
+  if (selection.active.character >= editor.document.lineAt(selection.active.line).range.end.character)
+    return builder.delete(new vscode.Range(line.range.end, line.rangeIncludingLineBreak.end))
 
-  return builder.delete(line.rangeIncludingLineBreak)
+  return builder.delete(selection)
 }
 
 registerCommand(Command.deleteYank, CommandFlags.Edit, async (editor, state, _, ctx) => {

--- a/src/commands/changes.ts
+++ b/src/commands/changes.ts
@@ -11,6 +11,18 @@ function getRegister(state: CommandState<any>, ctx: Extension) {
   return state.currentRegister || ctx.registers.dquote
 }
 
+function deleteSelection(builder: vscode.TextEditorEdit, editor: vscode.TextEditor, selection: vscode.Selection) {
+  if (!selection.isEmpty)
+    return builder.delete(selection)
+
+  const line = editor.document.lineAt(selection.active.line)
+
+  if (!line.range.isEmpty)
+    return builder.delete(selection)
+
+  return builder.delete(line.rangeIncludingLineBreak)
+}
+
 registerCommand(Command.deleteYank, CommandFlags.Edit, async (editor, state, _, ctx) => {
   const reg = getRegister(state, ctx)
 
@@ -19,7 +31,7 @@ registerCommand(Command.deleteYank, CommandFlags.Edit, async (editor, state, _, 
 
   return (builder: vscode.TextEditorEdit) => {
     for (const selection of editor.selections)
-      builder.delete(selection)
+      deleteSelection(builder, editor, selection)
   }
 })
 
@@ -31,18 +43,18 @@ registerCommand(Command.deleteInsertYank, CommandFlags.Edit | CommandFlags.Switc
 
   return (builder: vscode.TextEditorEdit) => {
     for (const selection of editor.selections)
-      builder.delete(selection)
+      deleteSelection(builder, editor, selection)
   }
 })
 
 registerCommand(Command.deleteNoYank, CommandFlags.Edit, editor => builder => {
   for (const selection of editor.selections)
-    builder.delete(selection)
+    deleteSelection(builder, editor, selection)
 })
 
 registerCommand(Command.deleteInsertNoYank, CommandFlags.Edit | CommandFlags.SwitchToInsert, editor => builder => {
   for (const selection of editor.selections)
-    builder.delete(selection)
+    deleteSelection(builder, editor, selection)
 })
 
 registerCommand(Command.yank, CommandFlags.None, (editor, state, _, ctx) => {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -143,6 +143,8 @@ export class CommandDescriptor<Input extends InputKind = InputKind> {
     if (!(flags & CommandFlags.IgnoreInHistory))
       history.addCommand(this, commandState)
 
+    state.ignoreSelectionChanges = true
+
     let result = this.action(editor, commandState, { undoStopBefore: true, undoStopAfter: true }, state)
 
     if (result !== undefined) {
@@ -174,6 +176,9 @@ export class CommandDescriptor<Input extends InputKind = InputKind> {
     } else if (remainingNormalCommands > 1) {
       remainingNormalCommands--
     }
+
+    state.ignoreSelectionChanges = false
+    state.normalizeSelections(editor)
   }
 
   /**

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -157,9 +157,15 @@ export class CommandDescriptor<Input extends InputKind = InputKind> {
       await state.setMode(Mode.Insert)
     } else if (flags & CommandFlags.SwitchToNormal) {
       await state.setMode(Mode.Normal)
+
+      // Force selection to be non-empty when switching to normal. This is only
+      // necessary because we do not restore selections yet.
+      // TODO: Remove this once https://github.com/71/dance/issues/31 is fixed.
+      state.normalizeSelections(editor)
     }
 
     if (flags & CommandFlags.ChangeSelections) {
+      state.normalizeSelections(editor)
       // Scroll to cursor if needed
       editor.revealRange(editor.selection)
     }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -157,11 +157,6 @@ export class CommandDescriptor<Input extends InputKind = InputKind> {
       await state.setMode(Mode.Insert)
     } else if (flags & CommandFlags.SwitchToNormal) {
       await state.setMode(Mode.Normal)
-
-      // Force selection to be non-empty when switching to normal. This is only
-      // necessary because we do not restore selections yet.
-      // TODO: Remove this once https://github.com/71/dance/issues/31 is fixed.
-      state.normalizeSelections(editor)
     }
 
     if (flags & CommandFlags.ChangeSelections) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -160,7 +160,6 @@ export class CommandDescriptor<Input extends InputKind = InputKind> {
     }
 
     if (flags & CommandFlags.ChangeSelections) {
-      state.normalizeSelections(editor)
       // Scroll to cursor if needed
       editor.revealRange(editor.selection)
     }

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -139,8 +139,9 @@ function moveDown(editor: vscode.TextEditor, expand: boolean, mult: number, allo
 }
 
 /**
- * Changes one character selections to be the direction specified. Return others unchanged.
- * @param selection the original selection. Will be reversed if needed
+ * Changes one character elections to be the direction specified. Return others unchanged.
+ *
+ * @param selection The original selection. Will be reversed if needed.
  * @param direction 1 for forward (active > anchor) or -1 for backward (active < anchor).
  */
 function fixDirection(selection: vscode.Selection, direction: -1 | 1) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,6 +154,8 @@ export class Extension implements vscode.Disposable {
   currentCount: number = 0
   currentRegister: Register | undefined = undefined
 
+  ignoreSelectionChanges = false
+
   readonly subscriptions: vscode.Disposable[] = []
 
   readonly statusBarItem: vscode.StatusBarItem
@@ -413,8 +415,8 @@ export class Extension implements vscode.Disposable {
   /**
    * Make all selections in the editor non-empty by selecting at least one character.
    */
-  private normalizeSelections(editor: vscode.TextEditor) {
-    if (this.allowEmptySelections)
+  normalizeSelections(editor: vscode.TextEditor) {
+    if (this.allowEmptySelections || this.ignoreSelectionChanges)
       return
     if (this.modeMap.get(editor.document) !== Mode.Normal)
       return
@@ -430,14 +432,14 @@ export class Extension implements vscode.Disposable {
           normalizedSelections = editor.selections.slice(0, i);
         }
 
-        const offset = editor.document.offsetAt(selection.active);
-        const nextPos = editor.document.positionAt(offset + 1);
-        if (nextPos.isAfter(selection.active)) {
+        const active = selection.active
+
+        if (active.character < editor.document.lineAt(active.line).range.end.character) {
           // Move anchor to select 1 character after, but keep the cursor position.
-          normalizedSelections.push(new vscode.Selection(nextPos, selection.active));
+          normalizedSelections.push(new vscode.Selection(active.translate(0, 1), active));
         } else {
-          // Selection is at the very end of the document. Select the last character instead.
-          normalizedSelections.push(new vscode.Selection(selection.anchor, editor.document.positionAt(offset - 1)));
+          // Selection is at the very end of the line. Select the last character instead.
+          normalizedSelections.push(new vscode.Selection(active, active.translate(0, -1)));
         }
       } else if (normalizedSelections)
         normalizedSelections.push(selection);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -437,6 +437,9 @@ export class Extension implements vscode.Disposable {
         if (active.character < editor.document.lineAt(active.line).range.end.character) {
           // Move anchor to select 1 character after, but keep the cursor position.
           normalizedSelections.push(new vscode.Selection(active.translate(0, 1), active));
+        } else if (active.character === 0) {
+          // Selection is on an empty line; we can't do much here.
+          normalizedSelections.push(selection);
         } else {
           // Selection is at the very end of the line. Select the last character instead.
           normalizedSelections.push(new vscode.Selection(active, active.translate(0, -1)));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -435,7 +435,7 @@ export class Extension implements vscode.Disposable {
       return
 
     // Since this is called every time when selection changes, avoid allocations
-    // unless really needed and iterate manually without using helper functions. 
+    // unless really needed and iterate manually without using helper functions.
     let normalizedSelections
 
     for (let i = 0; i < editor.selections.length; i++) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -218,6 +218,13 @@ export class Extension implements vscode.Disposable {
   }
 
   setEditorMode(editor: vscode.TextEditor, mode: Mode) {
+    if (mode === Mode.Normal) {
+      // Force selection to be non-empty when switching to normal. This is only
+      // necessary because we do not restore selections yet.
+      // TODO: Remove this once https://github.com/71/dance/issues/31 is fixed.
+      this.normalizeSelections(editor)
+    }
+
     if (this.modeMap.get(editor.document) === mode)
       return Promise.resolve()
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,6 +147,7 @@ export class Extension implements vscode.Disposable {
 
   enabled: boolean = false
   private allowEmptySelections: boolean = true
+  private normalizeTimeoutToken: NodeJS.Timeout | undefined
 
   typeCommand: vscode.Disposable | undefined = undefined
   changeEditorCommand: vscode.Disposable | undefined = undefined
@@ -389,7 +390,18 @@ export class Extension implements vscode.Disposable {
           else
             this.setDecorations(e.textEditor, this.normalMode.decorationType)
 
-          this.normalizeSelections(e.textEditor)
+          if (this.normalizeTimeoutToken !== undefined) {
+            clearTimeout(this.normalizeTimeoutToken)
+            this.normalizeTimeoutToken = undefined
+          }
+
+          if (e.kind === vscode.TextEditorSelectionChangeKind.Mouse) {
+            this.normalizeTimeoutToken = setTimeout(() => {
+              this.normalizeSelections(e.textEditor)
+              this.normalizeTimeoutToken = undefined
+            }, 200)
+          } else
+            this.normalizeSelections(e.textEditor)
         }),
 
         vscode.workspace.onDidChangeConfiguration(e => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,6 +146,7 @@ export class Extension implements vscode.Disposable {
   configuration = vscode.workspace.getConfiguration(extensionName)
 
   enabled: boolean = false
+  private allowEmptySelections: boolean = true
 
   typeCommand: vscode.Disposable | undefined = undefined
   changeEditorCommand: vscode.Disposable | undefined = undefined
@@ -192,6 +193,10 @@ export class Extension implements vscode.Disposable {
       this.insertMode.updateCursorStyle(this, 'inherit')
       this.normalMode.updateCursorStyle(this, 'inherit')
     })
+
+    this.observePreference<boolean>('selections.allowEmpty', true, value => {
+      this.allowEmptySelections = value;
+    }, true);
   }
 
   updateDecorations(mode: ModeConfiguration, color: string | null) {
@@ -399,8 +404,10 @@ export class Extension implements vscode.Disposable {
    * Make all selections in the editor non-empty by selecting at least one character.
    */
   normalizeSelections(editor: vscode.TextEditor) {
-    if (this.modeMap.get(editor.document) !== Mode.Normal) { return; }
-    if (this.configuration.get('selections.allowEmpty')) { return; }
+    if (this.allowEmptySelections)
+      return
+    if (this.modeMap.get(editor.document) !== Mode.Normal)
+      return
     if (editor.selections.some(sel => sel.isEmpty)) {
       editor.selections = editor.selections.map(selection => {
         if (!selection.isEmpty) { return selection; }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,8 +175,8 @@ export class Extension implements vscode.Disposable {
 
     // This needs to be before setEnabled for normalizing selections on start.
     this.observePreference<boolean>('selections.allowEmpty', true, value => {
-      this.allowEmptySelections = value;
-    }, true);
+      this.allowEmptySelections = value
+    }, true)
 
     this.setEnabled(this.configuration.get('enabled', true), false)
 
@@ -430,28 +430,31 @@ export class Extension implements vscode.Disposable {
   normalizeSelections(editor: vscode.TextEditor) {
     if (this.allowEmptySelections || this.ignoreSelectionChanges)
       return
+
     if (this.modeMap.get(editor.document) !== Mode.Normal)
       return
 
     // Since this is called every time when selection changes, avoid allocations
     // unless really needed and iterate manually without using helper functions. 
-    let normalizedSelections;
+    let normalizedSelections
+
     for (let i = 0; i < editor.selections.length; i++) {
-      const selection = editor.selections[i];
+      const selection = editor.selections[i]
       if (selection.isEmpty) {
         if (!normalizedSelections) {
           // Change needed. Allocate the new array and copy what we have so far.
-          normalizedSelections = editor.selections.slice(0, i);
+          normalizedSelections = editor.selections.slice(0, i)
         }
 
         const active = selection.active
 
         if (active.character >= editor.document.lineAt(active.line).range.end.character) {
           // Selection is at line end. Just keep it that way.
-          normalizedSelections.push(selection);
+          normalizedSelections.push(selection)
         } else {
           const offset = editor.document.offsetAt(selection.active)
           const nextPos = editor.document.positionAt(offset + 1)
+
           if (nextPos.isAfter(selection.active)) {
             // Move anchor to select 1 character after, but keep the cursor position.
             normalizedSelections.push(new vscode.Selection(active.translate(0, 1), active))
@@ -461,10 +464,11 @@ export class Extension implements vscode.Disposable {
           }
         }
       } else if (normalizedSelections)
-        normalizedSelections.push(selection);
+        normalizedSelections.push(selection)
     }
+
     if (normalizedSelections)
-      editor.selections = normalizedSelections;
+      editor.selections = normalizedSelections
   }
 
   dispose() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -386,6 +386,8 @@ export class Extension implements vscode.Disposable {
             this.setDecorations(e.textEditor, this.insertMode.decorationType)
           else
             this.setDecorations(e.textEditor, this.normalMode.decorationType)
+
+          this.normalizeSelections(e.textEditor)
         }),
 
         vscode.workspace.onDidChangeConfiguration(e => {
@@ -411,7 +413,7 @@ export class Extension implements vscode.Disposable {
   /**
    * Make all selections in the editor non-empty by selecting at least one character.
    */
-  normalizeSelections(editor: vscode.TextEditor) {
+  private normalizeSelections(editor: vscode.TextEditor) {
     if (this.allowEmptySelections)
       return
     if (this.modeMap.get(editor.document) !== Mode.Normal)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,7 +147,7 @@ export class Extension implements vscode.Disposable {
 
   enabled: boolean = false
 
-  private allowEmptySelections: boolean = true
+  allowEmptySelections: boolean = true
   private normalizeTimeoutToken: NodeJS.Timeout | undefined = undefined
 
   typeCommand: vscode.Disposable | undefined = undefined

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -434,15 +434,19 @@ export class Extension implements vscode.Disposable {
 
         const active = selection.active
 
-        if (active.character < editor.document.lineAt(active.line).range.end.character) {
-          // Move anchor to select 1 character after, but keep the cursor position.
-          normalizedSelections.push(new vscode.Selection(active.translate(0, 1), active));
-        } else if (active.character === 0) {
-          // Selection is on an empty line; we can't do much here.
+        if (active.character >= editor.document.lineAt(active.line).range.end.character) {
+          // Selection is at line end. Just keep it that way.
           normalizedSelections.push(selection);
         } else {
-          // Selection is at the very end of the line. Select the last character instead.
-          normalizedSelections.push(new vscode.Selection(active, active.translate(0, -1)));
+          const offset = editor.document.offsetAt(selection.active)
+          const nextPos = editor.document.positionAt(offset + 1)
+          if (nextPos.isAfter(selection.active)) {
+            // Move anchor to select 1 character after, but keep the cursor position.
+            normalizedSelections.push(new vscode.Selection(active.translate(0, 1), active))
+          } else {
+            // Selection is at the very end of the document. Select the last character instead.
+            normalizedSelections.push(new vscode.Selection(active, active.translate(0, -1)))
+          }
         }
       } else if (normalizedSelections)
         normalizedSelections.push(selection);


### PR DESCRIPTION
This defaults to true (existing behavior). When set to false, all selections keep at least one character.

Fixes #44.

Note that even with this change, the selection is not fully Kak/Vim-like. In kak, one-character selections have the same anchor and cursor and thus can be extended to either side, where as in VSCode one-character selections can be either forward or backwards, and will respond differently to expansions in Dance. Fixing that will require a much larger PR.