### PR TITLE
correct scrolling when selection range > visible range

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -163,7 +163,8 @@ export class CommandDescriptor<Input extends InputKind = InputKind> {
 
     if (flags & CommandFlags.ChangeSelections) {
       // Scroll to cursor if needed
-      editor.revealRange(editor.selection)
+      const position = editor.selection.active
+      editor.revealRange(new vscode.Range(position, position))
     }
 
     if (!this.command.startsWith('dance.count.'))


### PR DESCRIPTION
Closes #61 

When the range of the selection was larger than the viewport, the revealRange command did scroll to the top of the selection, hiding the cursor. This pull request improves this behavior by making sure that the cursor is always visible.