### PR TITLE
fix incorrect range select

### DIFF
--- a/src/commands/selectObject.ts
+++ b/src/commands/selectObject.ts
@@ -377,6 +377,7 @@ function performObjectSelect(editor: vscode.TextEditor, count: number, inner: bo
   lastObjectSelectOperation = [inner, type, extend, toStart, toEnd]
 
   editor.selections = editor.selections.map(selection => {
+    const anchor = selection.active
     let start = selection.start
     let end = selection.end
     let inInfiniteLooop = false
@@ -386,7 +387,7 @@ function performObjectSelect(editor: vscode.TextEditor, count: number, inner: bo
           sameEnd = true
 
       if (toStart) {
-        const buf = new TextBuffer(editor.document, start)
+        const buf = new TextBuffer(editor.document, anchor)
         const r = findObjectStart(buf, type, inner)
 
         if (r === undefined)
@@ -397,7 +398,7 @@ function performObjectSelect(editor: vscode.TextEditor, count: number, inner: bo
       }
 
       if (toEnd) {
-        const buf = new TextBuffer(editor.document, end)
+        const buf = new TextBuffer(editor.document, anchor)
         const r = findObjectEnd(buf, type, inner)
 
         if (r === undefined)


### PR DESCRIPTION
Object select in dance are incorrect when the selection is bigger than the object

Assuming the cursor is on the right
`tw[o words]` + <a-i>w produce `[two words]` in dance when it should select `two [words]`

This pull request corrects this behavior.