### PR TITLE
correct isAlphaWord to handle non latin characters

### DIFF
--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -219,7 +219,8 @@ function isPunctuation(c: string) {
 }
 
 export function isAlphaWord(c: string) {
-  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (c === '_') || (c === '-')
+  const wordSeparators = vscode.workspace.getConfiguration("editor").get("wordSeparators")
+  return !String(wordSeparators).includes(c) && c !== ' ' && c !== '\t' && c !== '\n'
 }
 
 function isNonWsWord(c: string) {


### PR DESCRIPTION
This pull request allows to reuse the editor native word separators.