### PR TITLE
correct selection order to be more kakoune-like

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -102,10 +102,10 @@ They are implemented in [`src/commands`](../src/commands).
 | `dance.macros.record.start` | Start recording macro | Start recording macro. | `Shift+Q` (`dance.mode == 'normal'`) |
 | `dance.macros.record.stop` | Stop recording macro | Stop recording macro. | `Escape` (`dance.mode == 'normal'`) |
 | `dance.macros.play` | Play macro | Play macro. | `Q` (`dance.mode == 'normal'`) |
-| `dance.rotate` | Rotate | Rotate each selection clockwise. | `Shift+0` (`dance.mode == 'normal'`) |
-| `dance.rotate.backwards` | Rotate backwards | Rotate each selection counter-clockwise. | `Shift+9` (`dance.mode == 'normal'`) |
-| `dance.rotate.content` | Rotate selection content | Rotate each selection (as well as its content) clockwise. | `Shift+Alt+0` (`dance.mode == 'normal'`) |
-| `dance.rotate.content.backwards` | Rotate selection content backwards | Rotate each selection (as well as its content) counter-clockwise. | `Shift+Alt+9` (`dance.mode == 'normal'`) |
+| `dance.rotate` | Rotate | Rotate each selection clockwise. | `Shift+9` (`dance.mode == 'normal'`) |
+| `dance.rotate.backwards` | Rotate backwards | Rotate each selection counter-clockwise. | `Shift+0` (`dance.mode == 'normal'`) |
+| `dance.rotate.content` | Rotate selection content | Rotate each selection (as well as its content) clockwise. | `Shift+Alt+9` (`dance.mode == 'normal'`) |
+| `dance.rotate.content.backwards` | Rotate selection content backwards | Rotate each selection (as well as its content) counter-clockwise. | `Shift+Alt+0` (`dance.mode == 'normal'`) |
 | `dance.rotate.contentOnly` | Rotate content only | Rotate each selection content clockwise, without changing selections. |  |
 | `dance.rotate.contentOnly.backwards` | Rotate content only backwards | Rotate each selection content counter-clockwise, without changing selections. |  |
 | `dance.search` | Search | Search for the given input string. | `/` (`dance.mode == 'normal'`) |

--- a/commands/commands.yaml
+++ b/commands/commands.yaml
@@ -482,22 +482,22 @@ macros.play:
 rotate:
   title: Rotate
   descr: Rotate each selection clockwise.
-  keys: s-0 (normal)
+  keys: s-9 (normal)
 
 rotate.backwards:
   title: Rotate backwards
   descr: Rotate each selection counter-clockwise.
-  keys: s-9 (normal)
+  keys: s-0 (normal)
 
 rotate.content:
   title: Rotate selection content
   descr: Rotate each selection (as well as its content) clockwise.
-  keys: s-a-0 (normal)
+  keys: s-a-9 (normal)
 
 rotate.content.backwards:
   title: Rotate selection content backwards
   descr: Rotate each selection (as well as its content) counter-clockwise.
-  keys: s-a-9 (normal)
+  keys: s-a-0 (normal)
 
 rotate.contentOnly:
   title: Rotate content only

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -1167,53 +1167,53 @@ export const macrosPlay: ICommand & { readonly id: 'dance.macros.play' } = {
 /**
  * Rotate each selection clockwise.
  *
- * Default key: `Shift+0` (`dance.mode == 'normal'`).
+ * Default key: `Shift+9` (`dance.mode == 'normal'`).
  */
 export const rotate: ICommand & { readonly id: 'dance.rotate' } = {
   id         : 'dance.rotate',
   title      : 'Rotate',
   description: 'Rotate each selection clockwise.',
   keybindings: [
-    { key: 'Shift+0', when: 'editorTextFocus && dance.mode == \'normal\'' },
+    { key: 'Shift+9', when: 'editorTextFocus && dance.mode == \'normal\'' },
   ],
 }
 /**
  * Rotate each selection counter-clockwise.
  *
- * Default key: `Shift+9` (`dance.mode == 'normal'`).
+ * Default key: `Shift+0` (`dance.mode == 'normal'`).
  */
 export const rotateBackwards: ICommand & { readonly id: 'dance.rotate.backwards' } = {
   id         : 'dance.rotate.backwards',
   title      : 'Rotate backwards',
   description: 'Rotate each selection counter-clockwise.',
   keybindings: [
-    { key: 'Shift+9', when: 'editorTextFocus && dance.mode == \'normal\'' },
+    { key: 'Shift+0', when: 'editorTextFocus && dance.mode == \'normal\'' },
   ],
 }
 /**
  * Rotate each selection (as well as its content) clockwise.
  *
- * Default key: `Shift+Alt+0` (`dance.mode == 'normal'`).
+ * Default key: `Shift+Alt+9` (`dance.mode == 'normal'`).
  */
 export const rotateContent: ICommand & { readonly id: 'dance.rotate.content' } = {
   id         : 'dance.rotate.content',
   title      : 'Rotate selection content',
   description: 'Rotate each selection (as well as its content) clockwise.',
   keybindings: [
-    { key: 'Shift+Alt+0', when: 'editorTextFocus && dance.mode == \'normal\'' },
+    { key: 'Shift+Alt+9', when: 'editorTextFocus && dance.mode == \'normal\'' },
   ],
 }
 /**
  * Rotate each selection (as well as its content) counter-clockwise.
  *
- * Default key: `Shift+Alt+9` (`dance.mode == 'normal'`).
+ * Default key: `Shift+Alt+0` (`dance.mode == 'normal'`).
  */
 export const rotateContentBackwards: ICommand & { readonly id: 'dance.rotate.content.backwards' } = {
   id         : 'dance.rotate.content.backwards',
   title      : 'Rotate selection content backwards',
   description: 'Rotate each selection (as well as its content) counter-clockwise.',
   keybindings: [
-    { key: 'Shift+Alt+9', when: 'editorTextFocus && dance.mode == \'normal\'' },
+    { key: 'Shift+Alt+0', when: 'editorTextFocus && dance.mode == \'normal\'' },
   ],
 }
 /**

--- a/package.json
+++ b/package.json
@@ -1583,22 +1583,22 @@
       },
       {
         "command": "dance.rotate",
-        "key": "Shift+0",
-        "when": "editorTextFocus && dance.mode == 'normal'"
-      },
-      {
-        "command": "dance.rotate.backwards",
         "key": "Shift+9",
         "when": "editorTextFocus && dance.mode == 'normal'"
       },
       {
+        "command": "dance.rotate.backwards",
+        "key": "Shift+0",
+        "when": "editorTextFocus && dance.mode == 'normal'"
+      },
+      {
         "command": "dance.rotate.content",
-        "key": "Shift+Alt+0",
+        "key": "Shift+Alt+9",
         "when": "editorTextFocus && dance.mode == 'normal'"
       },
       {
         "command": "dance.rotate.content.backwards",
-        "key": "Shift+Alt+9",
+        "key": "Shift+Alt+0",
         "when": "editorTextFocus && dance.mode == 'normal'"
       },
       {

--- a/src/commands/multiple.ts
+++ b/src/commands/multiple.ts
@@ -18,7 +18,7 @@ registerCommand(Command.select, CommandFlags.ChangeSelections, InputKind.RegExp,
       const anchor = editor.document.positionAt(selectionAnchorOffset + match.index)
       const active = editor.document.positionAt(selectionAnchorOffset + match.index + match[0].length)
 
-      newSelections.push(new vscode.Selection(anchor, active))
+      newSelections.unshift(new vscode.Selection(anchor, active))
 
       if (match[0].length === 0)
         regex.lastIndex++


### PR DESCRIPTION
In kakoune, when using select on a block of text, the last occurence of the selected string is set set as the main selection. This pull request also change the rotate commands to be coherent with the change.