### PR TITLE
[WIP] Work on <a-p> to paste all

### DIFF
--- a/src/commands/changes.ts
+++ b/src/commands/changes.ts
@@ -170,16 +170,16 @@ registerCommand(Command.pasteSelectAfter, CommandFlags.ChangeSelections | Comman
         reverseSelection = [] as boolean[]
 
   await editor.edit(builder => {
-    for (let i = 0; i < contents.length; i++) {
-      const content = contents[i],
-            selection = selections[i]
-
-      if (content.endsWith('\n'))
-        builder.replace(selection.end.with(selection.end.line + 1, 0), content)
-      else
-        builder.replace(selection.end, content)
-
-      reverseSelection.push(selection.isEmpty)
+    for (let i = 0; i < selections.length; i++) {
+      const selection = selections[i]
+      for (let j = 0; j < contents.length; j++) {
+        const content = contents[i]
+        if (content.endsWith('\n'))
+          builder.replace(selection.end.with(selection.end.line + 1, 0), content)
+        else
+          builder.replace(selection.end, content)
+        reverseSelection.push(selection.isEmpty)
+      }
     }
   }, undoStops)
 


### PR DESCRIPTION
This is a first cut at something to make `<a-p>` act more like Kakoune (#81) and make it "paste all".

It seems to work like Kakoune for selections that are not full lines. For selections involving full lines, it doesn't include the `\n`. If I do `%<a-s>y`, the text copied from each line doesn't include the line endings. So, I'm not sure how to make this work. 