### PR TITLE
WIP: API idea for selection helper.

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -99,8 +99,8 @@ export class SelectionHelper {
       )
     } else {
       return new vscode.Selection(
-        this.context.editor.document.positionAt(activeChar + 1),
-        this.context.editor.document.positionAt(anchorChar),
+        this.context.editor.document.positionAt(anchorChar + 1),
+        this.context.editor.document.positionAt(activeChar),
       )
     }
   }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -52,6 +52,21 @@ export type SelectionContext = {
 export type SkipFunc = (from: number, context: SelectionContext, i: number) => number;
 export type SelectFunc = (from: number, context: SelectionContext, i: number) => number;
 
+export enum MoveMode {
+  /** Move to cover the character at offset / after position. */
+  ToCoverChar,
+  /** Move to touch, but not cover the character at offset / after position. */
+  UntilChar,
+  /**
+   * Move so that:
+   * - If !allowEmpty, exactly the same as ToCoverChar.
+   * - If allowEmpty, active is exactly at position / offset. (The selection may
+   *   or may not cover the character at offset / after position, depending on
+   *   the direction of the selection.)
+   */
+  To,
+}
+
 export class SelectionHelper {
   context!: SelectionContext;
   get allowEmpty() {
@@ -59,22 +74,6 @@ export class SelectionHelper {
   }
   get allowNonDirectional() {
     return !this.context.extension.allowEmptySelections
-  }
-
-  moveEach(skip: SkipFunc, select: SelectFunc, extend: ExtendBehavior): void {
-    const newSelections: vscode.Selection[] = []
-    const editor = this.context.editor
-    for (let i = 0; i < editor.selections.length; i++) {
-      const startAt = this.activeOffset(editor.selections[i])
-      const skipTo = skip(startAt, this.context, i)
-      const endAt = select(skipTo, this.context, i)
-      if (extend) {
-        newSelections.push(this.extendToInclude(editor.selections[i], endAt))
-      } else {
-        newSelections.push(this.createSelectionBetween(skipTo, endAt))
-      }
-    }
-    editor.selections = newSelections
   }
 
   activeOffset(selection: vscode.Selection) {
@@ -86,52 +85,63 @@ export class SelectionHelper {
       return this.context.editor.document.offsetAt(selection.active) - 1
     }
   }
-  createSelectionBetween(anchorChar: number, activeChar: number): vscode.Selection {
-    if (!this.allowNonDirectional) {
-      return new vscode.Selection(
-        this.context.editor.document.positionAt(anchorChar),
-        this.context.editor.document.positionAt(activeChar),
-      )
-    } else if (anchorChar <= activeChar) {
-      return new vscode.Selection(
-        this.context.editor.document.positionAt(anchorChar),
-        this.context.editor.document.positionAt(activeChar + 1),
-      )
-    } else {
-      return new vscode.Selection(
-        this.context.editor.document.positionAt(anchorChar + 1),
-        this.context.editor.document.positionAt(activeChar),
-      )
+
+  moveEach(mode: MoveMode, skip: SkipFunc, select: SelectFunc, extend: ExtendBehavior): void {
+    const newSelections: vscode.Selection[] = []
+    const editor = this.context.editor
+    for (let i = 0; i < editor.selections.length; i++) {
+      const startAt = this.activeOffset(editor.selections[i])
+      console.log('START', this._visualizeOffset(startAt))
+      const skipTo = skip(startAt, this.context, i)
+      console.log(' SKIP', this._visualizeOffset(skipTo))
+      const endAt = select(skipTo, this.context, i)
+      console.log(' END-', this._visualizeOffset(endAt))
+      if (extend) {
+        newSelections.push(this.extend(editor.selections[i], mode, endAt))
+      } else {
+        const skipPos = this.context.editor.document.positionAt(skipTo)
+        // TODO: Optimize
+        newSelections.push(this.extend(
+          new vscode.Selection(skipPos, this.allowEmpty
+            ? skipPos : this.context.editor.document.positionAt(skipTo + 1)),
+          mode,
+          endAt))
+      }
     }
+    editor.selections = newSelections
   }
-  extendToInclude(oldSelection: vscode.Selection, activeChar: number): vscode.Selection {
+
+  extend(oldSelection: vscode.Selection, mode: MoveMode, active: number): vscode.Selection {
     const document = this.context.editor.document
     const oldAnchorOffset = document.offsetAt(oldSelection.anchor)
-    if (oldAnchorOffset <= activeChar) {
+    if (oldAnchorOffset <= active) {
+      const shouldCoverActive = (mode === MoveMode.ToCoverChar || (mode === MoveMode.To && !this.allowEmpty))
+      const offset = shouldCoverActive ? 1 : 0
       if (oldSelection.isReversed && this.allowNonDirectional) {
         // BEFORE: |abc>de ==> AFTER: ab<cd|e or ab<c|de (single char forward).
         // Note that we need to decrement anchor to include the first char.
         const newAnchor = document.positionAt(oldAnchorOffset - 1)
-        return new vscode.Selection(newAnchor, document.positionAt(activeChar + 1))
+        return new vscode.Selection(newAnchor, document.positionAt(active + offset))
       } else {
         // BEFORE:    |abc>de ==> AFTER: abc<d|e or abc<|de (empty).
         // OR BEFORE: <abc|de ==> AFTER: <abcd|e.
-        const includeBoundary = this.allowNonDirectional ? 1 : 0
-        return new vscode.Selection(oldSelection.anchor, document.positionAt(activeChar + includeBoundary))
+        return new vscode.Selection(oldSelection.anchor, document.positionAt(active + offset))
       }
     } else {
+      const shouldCoverActive = (mode === MoveMode.ToCoverChar || (mode === MoveMode.To && this.allowEmpty))
+      const offset = shouldCoverActive ? 0 : 1
       if (!oldSelection.isReversed && this.allowNonDirectional) {
         // BEFORE: ab<cd|e ==> AFTER: a|bc>de.
         // Note that we need to increment anchor to include the last char.
         const newAnchor = document.positionAt(oldAnchorOffset + 1)
-        return new vscode.Selection(newAnchor, document.positionAt(activeChar))
-      } else if (oldAnchorOffset === activeChar + 1 && this.allowNonDirectional) {
+        return new vscode.Selection(newAnchor, document.positionAt(active + offset))
+      } else if (oldAnchorOffset === active + 1 && this.allowNonDirectional) {
         // BEFORE: a|bc>de ==> AFTER: ab<c|de (FORCE single char forward).
-        return new vscode.Selection(document.positionAt(activeChar), oldSelection.anchor)
+        return new vscode.Selection(document.positionAt(active + offset), oldSelection.anchor)
       } else {
         // BEFORE:    ab<cd|e ==> AFTER: a|b>cde.
         // OR BEFORE: ab|cd>e ==> AFTER: a|bcd>e.
-        return new vscode.Selection(oldSelection.anchor, document.positionAt(activeChar))
+        return new vscode.Selection(oldSelection.anchor, document.positionAt(active + offset))
       }
     }
   }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -128,7 +128,7 @@ export class SelectionHelper {
         return new vscode.Selection(oldSelection.anchor, document.positionAt(active + offset))
       }
     } else {
-      const shouldCoverActive = (mode === MoveMode.ToCoverChar || (mode === MoveMode.To && this.allowEmpty))
+      const shouldCoverActive = (mode === MoveMode.ToCoverChar || mode === MoveMode.To)
       const offset = shouldCoverActive ? 0 : 1
       if (!oldSelection.isReversed && this.allowNonDirectional) {
         // BEFORE: ab<cd|e ==> AFTER: a|bc>de.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -466,6 +466,7 @@ export class Extension implements vscode.Disposable {
    * Make all selections in the editor non-empty by selecting at least one character.
    */
   normalizeSelections(editor: vscode.TextEditor) {
+    return // Disabled for now for easier development.
     if (this.allowEmptySelections || this.ignoreSelectionChanges)
       return
 


### PR DESCRIPTION
This is a WIP for a new selection helper that handles both extending and moving + both allowEmpty or not.

I think I've got the semantics right and the API is likely going to stay largely unchanged. I have only updated `hjkl` and `tf` (+ variants) to use the new API and I may do a few more later, but I'd love to hear your thoughts first.

There are some closures but they're all created during initialization, so I believe they're fine during command execution. Also, most small functions are likely going to be inlined by V8, although I haven't done any benchmarks yet. I've tried to keep allocations to a minimum but feel free to suggest more ways to improve.