### PR TITLE
Improve menu items merging.

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,10 @@
               "items": {
                 "type": "object",
                 "additionalProperties": {
-                  "type": "object",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
                   "properties": {
                     "text": {
                       "type": "string"

--- a/package.ts
+++ b/package.ts
@@ -199,7 +199,7 @@ const pkg = {
               items: {
                 type: 'object',
                 additionalProperties: {
-                  type: 'object',
+                  type: ['object', 'null'],
                   properties: {
                     'text': {
                       type: 'string',

--- a/src/state/extension.ts
+++ b/src/state/extension.ts
@@ -309,7 +309,9 @@ export class Extension implements vscode.Disposable {
             const item = menu.items[key],
                   itemDisplay = `${JSON.stringify(key)} of ${menuDisplay}`
 
-            if (item === null) continue
+            if (item === null)
+              continue
+
             if (typeof item !== 'object') {
               vscode.window.showErrorMessage(`Item ${itemDisplay} must be an object.`)
             } else if (typeof item.text !== 'string' || item.text.length === 0) {

--- a/src/state/extension.ts
+++ b/src/state/extension.ts
@@ -28,12 +28,14 @@ export namespace ModeConfiguration {
   export type LineNumbers = 'on' | 'off' | 'relative' | 'inherit'
 }
 
+export interface GotoMenuItem {
+  readonly text: string
+  readonly command: string
+  readonly args?: any[]
+}
+
 export interface GotoMenu {
-  readonly items: Record<string, {
-    readonly text: string
-    readonly command: string
-    readonly args?: any[]
-  }>
+  readonly items: Record<string, GotoMenuItem>
 }
 
 /**
@@ -281,7 +283,7 @@ export class Extension implements vscode.Disposable {
     }, true)
 
     // Configuration: menus.
-    this.observePreference<Record<string, GotoMenu>>('menus', {}, value => {
+    this.observePreference<Record<string, { items: Record<string, GotoMenuItem | null> }>>('menus', {}, value => {
       this._gotoMenus.clear()
 
       if (typeof value !== 'object' || value === null) {
@@ -301,13 +303,14 @@ export class Extension implements vscode.Disposable {
           vscode.window.showErrorMessage(`Menu ${menuDisplay} must have an subobject "items" with at least two entries.`)
         } else {
           let valid = true
-          const allKeys = new Set<number>()
+          const seenKeyCodes = new Map<number, string>()
 
           for (const key in menu.items) {
             const item = menu.items[key],
                   itemDisplay = `${JSON.stringify(key)} of ${menuDisplay}`
 
-            if (typeof item !== 'object' || item === null) {
+            if (item === null) continue
+            if (typeof item !== 'object') {
               vscode.window.showErrorMessage(`Item ${itemDisplay} must be an object.`)
             } else if (typeof item.text !== 'string' || item.text.length === 0) {
               vscode.window.showErrorMessage(`Item ${itemDisplay} must have a non-empty "text" property.`)
@@ -320,9 +323,12 @@ export class Extension implements vscode.Disposable {
                 vscode.window.showErrorMessage(`Item ${itemDisplay} must be a non-empty string key.`)
               } else {
                 for (let i = 0; i < key.length; i++) {
-                  if (allKeys.size === allKeys.add(key.charCodeAt(i)).size) {
-                    vscode.window.showErrorMessage(`Menu ${menuDisplay} specifies the key '${key}' more than once.`)
+                  let keyCode = key.charCodeAt(i),
+                      prevKey = seenKeyCodes.get(keyCode)
+                  if (prevKey) {
+                    vscode.window.showErrorMessage(`Menu ${menuDisplay} has duplicate key '${key[i]}' (specified by '${prevKey}' and '${key}').`)
                   } else {
+                    seenKeyCodes.set(keyCode, key)
                     keyString = keyString === '' ? key[i] : `${keyString}, ${key[i]}`
                     continue
                   }


### PR DESCRIPTION
It turns out VSCode already merges user-specified menu objects with the Dance default menu objects. From [API documentation](https://github.com/yuchenshi/dance/pull/new/merge-menu):

> The effective value (returned by get) is computed by overriding or merging the values in the following order.
> **Note: Only object value types are merged and all other value types are overridden.**

I've improved the error handling logic to show the exact key definitions in conflict, which should help users troubleshoot conflicts more easily.

For example, in the case of:

```json
      "object": {
        "items": {
          "b": { "command": "xxx", "text": "xxx" },
        },
      }
```

This now shows that there is a conflict between `b()` (from default) and `b` (from user settings). I've also made it possible to work around this situation by allowing removing items, like:

```json
      "object": {
        "items": {
          "b()": null,
          "b": { "command": "xxx", "text": "xxx" },
        },
      }
```

The snippet above first removes `b()` from the menu and then adds an item with only `b`. Should user want the default behavior back for `(` and `)`, they can also add those back manually as one or two separate items.