### PR TITLE
Correct selection order of dance.select command.

### DIFF
--- a/src/commands/selections.ts
+++ b/src/commands/selections.ts
@@ -150,7 +150,7 @@ registerCommand(Command.select, CommandFlags.ChangeSelections, InputKind.RegExp,
       const anchor = document.positionAt(selectionStartOffset + match.index)
       const active = document.positionAt(selectionStartOffset + match.index + match[0].length)
 
-      newSelections.push(new vscode.Selection(anchor, active))
+      newSelections.unshift(new vscode.Selection(anchor, active))
 
       if (match[0].length === 0)
         regex.lastIndex++

--- a/src/commands/selections.ts
+++ b/src/commands/selections.ts
@@ -340,7 +340,7 @@ function copySelections(editorState: EditorState, { repetitions }: CommandState,
 
       if (copiedSelection !== undefined) {
         if (!selections.some(s => s.contains(copiedSelection)))
-          selections.push(copiedSelection)
+          selections.unshift(copiedSelection)
 
         i++
 


### PR DESCRIPTION
Another small pull request, similar to #78 

```
[test
test
test
test]
```

\+ `dance.select` ->

```
[test]
[test]
[test]
[[test]]
```