### PR TITLE
view menu

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -135,6 +135,10 @@ They are implemented in [`src/commands`](../src/commands).
 | `dance.goto.lastVisibleLine` | Go to last visible line | Go to last visible line. |  |
 | `dance.goto.selectedFile` | Open file under selection | Open file under selection. |  |
 | `dance.goto.lastModification` | Go to last buffer modification position | Go to last buffer modification position. |  |
+| `dance.view` | View... | Shows prompt to change view | `V` (`dance.mode == 'normal'`) |
+| `dance.view.center.vertical` | Center cursor | Centers the cursor |  |
+| `dance.view.top` | Cursor on top | Moves the cursor to the top |  |
+| `dance.view.bottom` | Cursor on bottom | Moves the cursor to the bottom |  |
 | `dance.openMenu` | Open quick-jump menu | Open quick-jump menu. |  |
 | `dance.registers.insert` | Insert value in register | Insert value in register. | `Ctrl+R` (`dance.mode == 'normal'`), `Ctrl+R` (`dance.mode == 'insert'`) |
 | `dance.registers.select` | Select register for next command | Select register for next command. | `Shift+\'` (`dance.mode == 'normal'`) |

--- a/commands/README.md
+++ b/commands/README.md
@@ -135,7 +135,7 @@ They are implemented in [`src/commands`](../src/commands).
 | `dance.goto.lastVisibleLine` | Go to last visible line | Go to last visible line. |  |
 | `dance.goto.selectedFile` | Open file under selection | Open file under selection. |  |
 | `dance.goto.lastModification` | Go to last buffer modification position | Go to last buffer modification position. |  |
-| `dance.view` | View... | Shows prompt to change view | `V` (`dance.mode == 'normal'`) |
+|  | View... | Shows prompt to change view | `V` (`dance.mode == 'normal'`) |
 | `dance.view.center.vertical` | Center cursor | Centers the cursor |  |
 | `dance.view.top` | Cursor on top | Moves the cursor to the top |  |
 | `dance.view.bottom` | Cursor on bottom | Moves the cursor to the bottom |  |

--- a/commands/commands.yaml
+++ b/commands/commands.yaml
@@ -643,6 +643,8 @@ view:
   title: View...
   descr: Shows prompt to change view
   keys: v (normal)
+  command: dance.openMenu
+  args: { menu: "view" }
 
 view.center.vertical:
   title: Center cursor

--- a/commands/commands.yaml
+++ b/commands/commands.yaml
@@ -636,6 +636,26 @@ goto.lastModification:
   title: Go to last buffer modification position
   add: extend
 
+# View (view.ts)
+# ================================================================================================
+
+view:
+  title: View...
+  descr: Shows prompt to change view
+  keys: v (normal)
+
+view.center.vertical:
+  title: Center cursor
+  descr: Centers the cursor
+
+view.top:
+  title: Cursor on top
+  descr: Moves the cursor to the top
+
+view.bottom:
+  title: Cursor on bottom
+  descr: Moves the cursor to the bottom
+
 # Menus (menus.ts)
 # ================================================================================================
 

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -1608,6 +1608,50 @@ export const gotoLastModification: ICommand<"dance.goto.lastModification"> = {
 };
 
 /**
+ * Shows prompt to change view
+ *
+ * Default key: `V` (`dance.mode == 'normal'`).
+ */
+export const view: ICommand<"dance.view"> = {
+  id         : "dance.view",
+  title      : "View...",
+  description: "Shows prompt to change view",
+  keybindings: [
+    { key: "v", when: "editorTextFocus && dance.mode == 'normal'" },
+  ],
+};
+
+/**
+ * Centers the cursor
+ */
+export const viewCenterVertical: ICommand<"dance.view.center.vertical"> = {
+  id         : "dance.view.center.vertical",
+  title      : "Center cursor",
+  description: "Centers the cursor",
+  keybindings: [],
+};
+
+/**
+ * Moves the cursor to the top
+ */
+export const viewTop: ICommand<"dance.view.top"> = {
+  id         : "dance.view.top",
+  title      : "Cursor on top",
+  description: "Moves the cursor to the top",
+  keybindings: [],
+};
+
+/**
+ * Moves the cursor to the bottom
+ */
+export const viewBottom: ICommand<"dance.view.bottom"> = {
+  id         : "dance.view.bottom",
+  title      : "Cursor on bottom",
+  description: "Moves the cursor to the bottom",
+  keybindings: [],
+};
+
+/**
  * Open quick-jump menu.
  */
 export const openMenu: ICommand<"dance.openMenu"> = {
@@ -2555,6 +2599,14 @@ export const commands = {
   gotoSelectedFile,
   /** Go to last buffer modification position. */
   gotoLastModification,
+  /** Shows prompt to change view */
+  view,
+  /** Centers the cursor */
+  viewCenterVertical,
+  /** Moves the cursor to the top */
+  viewTop,
+  /** Moves the cursor to the bottom */
+  viewBottom,
   /** Open quick-jump menu. */
   openMenu,
   /** Insert value in register. */
@@ -2905,6 +2957,14 @@ export const enum Command {
   gotoSelectedFile = "dance.goto.selectedFile",
   /** Go to last buffer modification position. */
   gotoLastModification = "dance.goto.lastModification",
+  /** Shows prompt to change view */
+  view = "dance.view",
+  /** Centers the cursor */
+  viewCenterVertical = "dance.view.center.vertical",
+  /** Moves the cursor to the top */
+  viewTop = "dance.view.top",
+  /** Moves the cursor to the bottom */
+  viewBottom = "dance.view.bottom",
   /** Open quick-jump menu. */
   openMenu = "dance.openMenu",
   /** Insert value in register. */

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -1608,20 +1608,6 @@ export const gotoLastModification: ICommand<"dance.goto.lastModification"> = {
 };
 
 /**
- * Shows prompt to change view
- *
- * Default key: `V` (`dance.mode == 'normal'`).
- */
-export const view: ICommand<"dance.view"> = {
-  id         : "dance.view",
-  title      : "View...",
-  description: "Shows prompt to change view",
-  keybindings: [
-    { key: "v", when: "editorTextFocus && dance.mode == 'normal'" },
-  ],
-};
-
-/**
  * Centers the cursor
  */
 export const viewCenterVertical: ICommand<"dance.view.center.vertical"> = {
@@ -2599,8 +2585,6 @@ export const commands = {
   gotoSelectedFile,
   /** Go to last buffer modification position. */
   gotoLastModification,
-  /** Shows prompt to change view */
-  view,
   /** Centers the cursor */
   viewCenterVertical,
   /** Moves the cursor to the top */
@@ -2957,8 +2941,6 @@ export const enum Command {
   gotoSelectedFile = "dance.goto.selectedFile",
   /** Go to last buffer modification position. */
   gotoLastModification = "dance.goto.lastModification",
-  /** Shows prompt to change view */
-  view = "dance.view",
   /** Centers the cursor */
   viewCenterVertical = "dance.view.center.vertical",
   /** Moves the cursor to the top */
@@ -3112,6 +3094,12 @@ export const additionalKeyBindings = [
     when   : "editorTextFocus && dance.mode == 'normal'",
     command: "dance.openMenu",
     args   : { "menu": "object", "action": "selectToEnd" },
+  },
+  {
+    key    : "v",
+    when   : "editorTextFocus && dance.mode == 'normal'",
+    command: "dance.openMenu",
+    args   : { "menu": "view" },
   },
   {
     key    : "Shift+;",

--- a/package.json
+++ b/package.json
@@ -459,6 +459,22 @@
                   "command": "dance.goto.lastModification.extend"
                 }
               }
+            },
+            "view": {
+              "items": {
+                "c": {
+                  "text": "Cursor center",
+                  "command": "dance.view.center.vertical"
+                },
+                "t": {
+                  "text": "Cursor top",
+                  "command": "dance.view.top"
+                },
+                "b": {
+                  "text": "Cursor bottom",
+                  "command": "dance.view.bottom"
+                }
+              }
             }
           }
         }
@@ -1177,6 +1193,30 @@
         "command": "dance.goto.lastModification",
         "title": "Go to last buffer modification position",
         "description": "Go to last buffer modification position.",
+        "category": "Dance"
+      },
+      {
+        "command": "dance.view",
+        "title": "View...",
+        "description": "Shows prompt to change view",
+        "category": "Dance"
+      },
+      {
+        "command": "dance.view.center.vertical",
+        "title": "Center cursor",
+        "description": "Centers the cursor",
+        "category": "Dance"
+      },
+      {
+        "command": "dance.view.top",
+        "title": "Cursor on top",
+        "description": "Moves the cursor to the top",
+        "category": "Dance"
+      },
+      {
+        "command": "dance.view.bottom",
+        "title": "Cursor on bottom",
+        "description": "Moves the cursor to the bottom",
         "category": "Dance"
       },
       {
@@ -2165,6 +2205,11 @@
       {
         "command": "dance.goto",
         "key": "g",
+        "when": "editorTextFocus && dance.mode == 'normal'"
+      },
+      {
+        "command": "dance.view",
+        "key": "v",
         "when": "editorTextFocus && dance.mode == 'normal'"
       },
       {

--- a/package.json
+++ b/package.json
@@ -1196,12 +1196,6 @@
         "category": "Dance"
       },
       {
-        "command": "dance.view",
-        "title": "View...",
-        "description": "Shows prompt to change view",
-        "category": "Dance"
-      },
-      {
         "command": "dance.view.center.vertical",
         "title": "Center cursor",
         "description": "Centers the cursor",
@@ -1593,6 +1587,14 @@
         "args": {
           "menu": "object",
           "action": "selectToEnd"
+        }
+      },
+      {
+        "key": "v",
+        "when": "editorTextFocus && dance.mode == 'normal'",
+        "command": "dance.openMenu",
+        "args": {
+          "menu": "view"
         }
       },
       {

--- a/package.ts
+++ b/package.ts
@@ -179,9 +179,9 @@ menus["view"] = {
     "b": {
       text: `Cursor bottom`,
       command: "dance.view.bottom",
-    }
-  }
-}
+    },
+  },
+};
 
 // Package information
 // ============================================================================

--- a/package.ts
+++ b/package.ts
@@ -166,6 +166,23 @@ for (const [suffix, desc] of [
   };
 }
 
+menus["view"] = {
+  items: {
+    "c": {
+      text: `Cursor center`,
+      command: "dance.view.center.vertical",
+    },
+    "t": {
+      text: `Cursor top`,
+      command: "dance.view.top",
+    },
+    "b": {
+      text: `Cursor bottom`,
+      command: "dance.view.bottom",
+    }
+  }
+}
+
 // Package information
 // ============================================================================
 
@@ -329,7 +346,7 @@ const pkg = {
           markdownEnumDescriptions: [
             "Selections are anchored to carets, which is the native VS Code behavior; that is, they are positioned *between* characters and can therefore be empty.",
             "Selections are anchored to characters, like Kakoune; that is, they are positioned *on* characters, and therefore cannot be empty. " +
-              "Additionally, one-character selections will behave as if they were non-directional, like Kakoune.",
+            "Additionally, one-character selections will behave as if they were non-directional, like Kakoune.",
           ],
         },
         "dance.menus": {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -486,4 +486,5 @@ import "./search";
 import "./select";
 import "./selections";
 import "./selectObject";
+import "./view";
 import "./yankPaste";

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -471,6 +471,7 @@ export function setRemainingNormalCommands(remaining: number) {
 import "./changes";
 import "./count";
 import "./goto";
+import "./view";
 import "./history";
 import "./insert";
 import "./macros";

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1,65 +1,23 @@
 import * as vscode from "vscode";
 
-import { Command, CommandFlags, CommandState, InputKind, registerCommand } from ".";
-import { EditorState } from "../state/editor";
+import { Command, CommandFlags, registerCommand } from ".";
 
-const getMenu = (name: string) => (editorState: EditorState) => {
-  const menuItems = editorState.extension.menus.get(name)!.items;
-
-  return Object.entries(menuItems).map((x) => [x[0], x[1].text]) as [string, string][];
-};
-
-const executeMenuItem = async (editorState: EditorState, name: string, i: number) => {
-  const menuItems = editorState.extension.menus.get(name)!.items;
-  const menuItem = Object.values(menuItems)[i];
-
-  try {
-    await vscode.commands.executeCommand(menuItem.command, menuItem.args);
-  } catch (e) {
-    const str = `${e}`.replace(/^Error: /, "");
-
-    vscode.window.showErrorMessage(`Command did not succeed successfully: ${str}.`);
-  }
-};
-
-// TODO: Make just merely opening the menu not count as a command execution
-// and do not record it.
-registerCommand(
-  Command.view,
-  CommandFlags.ChangeSelections,
-  InputKind.ListOneItemOrCount,
-  getMenu("view"),
-  (editorState, state) => {
-    if (state.input !== null)
-      return executeMenuItem(editorState, "view", state.input);
-    return;
-  },
-);
-
-async function toCenter() {
-  let currentLineNumber = vscode.window.activeTextEditor?.selection.start.line;
-  await vscode.commands.executeCommand("revealLine", {
-    lineNumber: currentLineNumber,
-    at: "center"
+function moveViewTo(lineNumber: number, at: "center" | "top" | "bottom") {
+  console.log("move view to: " + lineNumber + ", at: " + at);
+  return vscode.commands.executeCommand("revealLine", {
+    lineNumber,
+    at,
   });
 }
 
-async function toTop() {
-  let currentLineNumber = vscode.window.activeTextEditor?.selection.start.line;
-  await vscode.commands.executeCommand("revealLine", {
-    lineNumber: currentLineNumber,
-    at: "top"
-  });
-}
+registerCommand(Command.viewCenterVertical, CommandFlags.None, ({ editor }) => {
+  const res = moveViewTo(editor.selection.start.line, "center");
+});
 
-async function toBottom() {
-  let currentLineNumber = vscode.window.activeTextEditor?.selection.start.line;
-  await vscode.commands.executeCommand("revealLine", {
-    lineNumber: currentLineNumber,
-    at: "bottom"
-  });
-}
+registerCommand(Command.viewTop, CommandFlags.None, ({ editor }) => {
+  moveViewTo(editor.selection.start.line, "top");
+});
 
-vscode.commands.registerCommand(Command.viewCenterVertical, async () => await toCenter());
-vscode.commands.registerCommand(Command.viewTop, async () => await toTop());
-vscode.commands.registerCommand(Command.viewBottom, async () => await toBottom());
+registerCommand(Command.viewBottom, CommandFlags.None, ({ editor }) => {
+  moveViewTo(editor.selection.start.line, "bottom");
+});

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1,0 +1,65 @@
+import * as vscode from "vscode";
+
+import { Command, CommandFlags, CommandState, InputKind, registerCommand } from ".";
+import { EditorState } from "../state/editor";
+
+const getMenu = (name: string) => (editorState: EditorState) => {
+  const menuItems = editorState.extension.menus.get(name)!.items;
+
+  return Object.entries(menuItems).map((x) => [x[0], x[1].text]) as [string, string][];
+};
+
+const executeMenuItem = async (editorState: EditorState, name: string, i: number) => {
+  const menuItems = editorState.extension.menus.get(name)!.items;
+  const menuItem = Object.values(menuItems)[i];
+
+  try {
+    await vscode.commands.executeCommand(menuItem.command, menuItem.args);
+  } catch (e) {
+    const str = `${e}`.replace(/^Error: /, "");
+
+    vscode.window.showErrorMessage(`Command did not succeed successfully: ${str}.`);
+  }
+};
+
+// TODO: Make just merely opening the menu not count as a command execution
+// and do not record it.
+registerCommand(
+  Command.view,
+  CommandFlags.ChangeSelections,
+  InputKind.ListOneItemOrCount,
+  getMenu("view"),
+  (editorState, state) => {
+    if (state.input !== null)
+      return executeMenuItem(editorState, "view", state.input);
+    return;
+  },
+);
+
+async function toCenter() {
+  let currentLineNumber = vscode.window.activeTextEditor?.selection.start.line;
+  await vscode.commands.executeCommand("revealLine", {
+    lineNumber: currentLineNumber,
+    at: "center"
+  });
+}
+
+async function toTop() {
+  let currentLineNumber = vscode.window.activeTextEditor?.selection.start.line;
+  await vscode.commands.executeCommand("revealLine", {
+    lineNumber: currentLineNumber,
+    at: "top"
+  });
+}
+
+async function toBottom() {
+  let currentLineNumber = vscode.window.activeTextEditor?.selection.start.line;
+  await vscode.commands.executeCommand("revealLine", {
+    lineNumber: currentLineNumber,
+    at: "bottom"
+  });
+}
+
+vscode.commands.registerCommand(Command.viewCenterVertical, async () => await toCenter());
+vscode.commands.registerCommand(Command.viewTop, async () => await toTop());
+vscode.commands.registerCommand(Command.viewBottom, async () => await toBottom());


### PR DESCRIPTION
First off, I love dance. Kakoune is so damn nice but I had some insurmountable kak-lsp issues which brought me back to VS Code. To my delight your little creation fit the bill nicely to get the Kak-inspired workflow in Code. Many Thanks!

This PR includes the base of the View menu from Kakoune. It has the following commands:
- **v**: open the view menu
- **c**: cursor to center
- **t**: cursor to top
- **b**: cursor to bottom

I am quite new to VS Code extension authoring so I had a few issues implementing this that are probably not done correctly. I couldn't quite figure out how the generator generates the menu map. It was only generating one item for me so I manually added the other items to it.

Launching/debugging the extension also wouldn't work for me (via f5 or the launch tasks) so I had to manually package and install the vsix each iteration. Not optimal workflow for sure!

If you can point me in the right direction as to how to properly generate the menus and debug/build for testing I can fix up the PR and make it proper.