### PR TITLE
Return result of shell as string

### DIFF
--- a/src/api/run.ts
+++ b/src/api/run.ts
@@ -334,7 +334,7 @@ export function execute(
   }
 
   return Context.WithoutActiveEditor.wrap(import("child_process").then((cp) =>
-    new Promise<{ readonly val: string } | { readonly err: string }>((resolve) => {
+    new Promise<string>((resolve, reject) => {
       const shell = getShell() ?? true,
             child = cp.spawn(command, { shell, stdio: "pipe" });
 
@@ -352,18 +352,16 @@ export function execute(
       child.once("error", (err) => {
         disposable.dispose();
 
-        resolve({ err: err.message });
+        reject(err.message);
       });
       child.once("exit", (code) => {
         disposable.dispose();
 
         code === 0
-          ? resolve({ val: stdout.trimRight() })
-          : resolve({
-            err: `Command exited with error ${code}: ${
+          ? resolve(stdout.trimRight())
+          : reject(`Command exited with error ${code}: ${
               stderr.length > 0 ? stderr.trimRight() : "<No error output>"
-            }`,
-          });
+            }`);
       });
     })),
   );

--- a/src/api/run.ts
+++ b/src/api/run.ts
@@ -352,16 +352,16 @@ export function execute(
       child.once("error", (err) => {
         disposable.dispose();
 
-        reject(err.message);
+        reject(err);
       });
       child.once("exit", (code) => {
         disposable.dispose();
 
         code === 0
           ? resolve(stdout.trimRight())
-          : reject(`Command exited with error ${code}: ${
+          : reject(new Error(`Command exited with error ${code}: ${
               stderr.length > 0 ? stderr.trimRight() : "<No error output>"
-            }`);
+            }`));
       });
     })),
   );


### PR DESCRIPTION
I ran into the issue that if I insert the result of a shell command (using `!`), I get the result as a JSON object.

So I execute the following command: `#echo test`
And I get the following output:

```
{"val":"test"}
```

This PR returns the result of executing a command as a string. So it would return "test" instead.
I don't know why the previous version returned the result as a JSON object, i.e. which usecase it is for. But this solution fits my usecase.