### PR TITLE
Fix menu abbr for goto with `g` and move screen with `v`

### DIFF
--- a/package.build.ts
+++ b/package.build.ts
@@ -431,7 +431,7 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
                   command: "dance.select.lineStart",
                   args: [{ skipBlank: true }],
                 },
-                "gk": {
+                "k": {
                   text: "to first line",
                   command: "dance.select.lineStart",
                   args: [{ count: 1 }],
@@ -476,7 +476,7 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
                 // - m, center cursor horizontally
                 // - h, scroll left
                 // - l, scroll right
-                "vc": {
+                "c": {
                   text: "center cursor vertically",
                   command: "dance.view.line",
                   args: [{ at: "center" }],


### PR DESCRIPTION
i think this menu abbr should be second char. already pressed first char `g`. not again `gk` but `k` just

![image](https://user-images.githubusercontent.com/906974/120826455-6e85e600-c595-11eb-83b1-875f17ee8ff3.png)

this makes sense :) 

- gk to k
- vc to c

anyway thanks this awesome project.
