### PR TITLE
Tweak conf section language

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you prefer character-based selections like Kakoune, please set
 wish to use character-based selections. This mode is designed to work with
 block-style cursors, so your configuration would typically look like:
 
-```js
+```jsonc
 "dance.modes": {
   "insert": {
     // ...


### PR DESCRIPTION
Switching to `js` for the config sample causes the comment to render as a comment. Bit unfortunate, but probably a net improvement :)

Love the project!