### PR TITLE
enable word highlighting for dance selection

### DIFF
--- a/src/api/selections.ts
+++ b/src/api/selections.ts
@@ -44,6 +44,7 @@ export function set(selections: readonly vscode.Selection[], context = Context.c
 
   context.selections = selections;
   reveal(selections[0], context);
+  vscode.commands.executeCommand("editor.action.wordHighlight.trigger");
 
   return selections;
 }


### PR DESCRIPTION
Does the same as VSCodeVim https://github.com/VSCodeVim/Vim/blob/6d76ea60d3ce97a20cc3c22ebf58a2d61e7705db/src/mode/modeHandler.ts#L1648