### PR TITLE
Align over multiple columns

### DIFF
--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -35,8 +35,8 @@ depending on the keyboard layout. The following layouts _will be_\* supported:
 <tr><td><a href="#edit.deindent.withIncomplete"><code>edit.deindent.withIncomplete</code></a></td><td>Deindent selected lines (including incomplete indent)</td><td><code>Shift+,</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="./edit.ts#L43"><code>edit.delete</code></a></td><td>Delete</td><td><code>Alt+D</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="./edit.ts#L44"><code>edit.delete-insert</code></a></td><td>Delete and switch to Insert</td><td><code>Alt+C</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
-<tr><td><a href="./edit.ts#L359"><code>edit.newLine.above.insert</code></a></td><td>Insert new line above and switch to insert</td><td><code>Shift+O</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
-<tr><td><a href="./edit.ts#L397"><code>edit.newLine.below.insert</code></a></td><td>Insert new line below and switch to insert</td><td><code>O</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
+<tr><td><a href="./edit.ts#L389"><code>edit.newLine.above.insert</code></a></td><td>Insert new line above and switch to insert</td><td><code>Shift+O</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
+<tr><td><a href="./edit.ts#L427"><code>edit.newLine.below.insert</code></a></td><td>Insert new line below and switch to insert</td><td><code>O</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="./edit.ts#L36"><code>edit.paste.after</code></a></td><td>Paste after</td><td></td></tr>
 <tr><td><a href="./edit.ts#L38"><code>edit.paste.after.select</code></a></td><td>Paste after and select</td><td><code>P</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="./edit.ts#L35"><code>edit.paste.before</code></a></td><td>Paste before</td><td></td></tr>
@@ -420,7 +420,7 @@ Default keybinding: `r` (kakoune: normal)
 
 <a name="edit.align" />
 
-### [`edit.align`](./edit.ts#L277-L290)
+### [`edit.align`](./edit.ts#L277-L285)
 
 Align selections.
 
@@ -435,7 +435,7 @@ Default keybinding: `&` (kakoune: normal)
 
 <a name="edit.copyIndentation" />
 
-### [`edit.copyIndentation`](./edit.ts#L305-L318)
+### [`edit.copyIndentation`](./edit.ts#L335-L348)
 
 Copy indentation.
 
@@ -450,7 +450,7 @@ Default keybinding: `a-&` (kakoune: normal)
 
 <a name="edit.newLine.above" />
 
-### [`edit.newLine.above`](./edit.ts#L347-L365)
+### [`edit.newLine.above`](./edit.ts#L377-L395)
 
 Insert new line above each selection.
 
@@ -472,7 +472,7 @@ Default keybinding: `s-a-o` (kakoune: normal)
 
 <a name="edit.newLine.below" />
 
-### [`edit.newLine.below`](./edit.ts#L385-L403)
+### [`edit.newLine.below`](./edit.ts#L415-L433)
 
 Insert new line below each selection.
 

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -2,7 +2,6 @@ import * as vscode from "vscode";
 
 import type { Argument, InputOr, RegisterOr } from ".";
 import { insert as apiInsert, Context, deindentLines, Direction, edit, indentLines, insertByIndex, insertByIndexWithFullLines, insertFlagsAtEdge, joinLines, keypress, Positions, replace, replaceByIndex, Selections, Shift } from "../api";
-import { sort } from "../api/selections";
 import type { Register } from "../state/registers";
 import { ArgumentError, LengthMismatchError } from "../utils/errors";
 
@@ -285,9 +284,9 @@ export async function replaceCharacters(
  */
 export function align(_: Context, fill: Argument<string> = " ") {
   return edit((builder, selections) => {
-    const sortedSelections = sort(Direction.Forward, [...selections]);
+    const sortedSelections = Selections.sort(Direction.Forward, [...selections]);
 
-    // Group selections by 'column', nth column being nth selections of each line
+    // Group selections by 'column', nth column being nth selections of each line.
     const selectionByColumn: vscode.Selection[][] = [];
     let currentLine: number | undefined = undefined;
     let currentColumn: number = 0;
@@ -311,7 +310,7 @@ export function align(_: Context, fill: Argument<string> = " ") {
       currentColumn += 1;
     }
     // Selections aren't updated as we fill each line, so we keep track of how
-    // many characters we added to each line as we go
+    // many characters we added to each line as we go.
     const lineFillCounters = new Map();
     const getAlignChar = (sel: vscode.Selection) =>
       sel.active.character + (lineFillCounters.get(sel.start.line) ?? 0);

--- a/src/commands/layouts/azerty.fr.md
+++ b/src/commands/layouts/azerty.fr.md
@@ -20,8 +20,8 @@
 <tr><td><a href="#edit.deindent.withIncomplete"><code>edit.deindent.withIncomplete</code></a></td><td>Deindent selected lines (including incomplete indent)</td><td><code>Shift+,</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../edit.ts#L43"><code>edit.delete</code></a></td><td>Delete</td><td><code>Alt+D</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../edit.ts#L44"><code>edit.delete-insert</code></a></td><td>Delete and switch to Insert</td><td><code>Alt+C</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
-<tr><td><a href="../edit.ts#L359"><code>edit.newLine.above.insert</code></a></td><td>Insert new line above and switch to insert</td><td><code>Shift+O</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
-<tr><td><a href="../edit.ts#L397"><code>edit.newLine.below.insert</code></a></td><td>Insert new line below and switch to insert</td><td><code>O</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
+<tr><td><a href="../edit.ts#L389"><code>edit.newLine.above.insert</code></a></td><td>Insert new line above and switch to insert</td><td><code>Shift+O</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
+<tr><td><a href="../edit.ts#L427"><code>edit.newLine.below.insert</code></a></td><td>Insert new line below and switch to insert</td><td><code>O</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../edit.ts#L36"><code>edit.paste.after</code></a></td><td>Paste after</td><td></td></tr>
 <tr><td><a href="../edit.ts#L38"><code>edit.paste.after.select</code></a></td><td>Paste after and select</td><td><code>P</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../edit.ts#L35"><code>edit.paste.before</code></a></td><td>Paste before</td><td></td></tr>
@@ -405,7 +405,7 @@ Default keybinding: `r` (kakoune: normal)
 
 <a name="edit.align" />
 
-### [`edit.align`](../edit.ts#L277-L290)
+### [`edit.align`](../edit.ts#L277-L285)
 
 Align selections.
 
@@ -420,7 +420,7 @@ Default keybinding: `&` (kakoune: normal)
 
 <a name="edit.copyIndentation" />
 
-### [`edit.copyIndentation`](../edit.ts#L305-L318)
+### [`edit.copyIndentation`](../edit.ts#L335-L348)
 
 Copy indentation.
 
@@ -435,7 +435,7 @@ Default keybinding: `a-&` (kakoune: normal)
 
 <a name="edit.newLine.above" />
 
-### [`edit.newLine.above`](../edit.ts#L347-L365)
+### [`edit.newLine.above`](../edit.ts#L377-L395)
 
 Insert new line above each selection.
 
@@ -457,7 +457,7 @@ Default keybinding: `s-a-o` (kakoune: normal)
 
 <a name="edit.newLine.below" />
 
-### [`edit.newLine.below`](../edit.ts#L385-L403)
+### [`edit.newLine.below`](../edit.ts#L415-L433)
 
 Insert new line below each selection.
 

--- a/src/commands/layouts/qwerty.md
+++ b/src/commands/layouts/qwerty.md
@@ -20,8 +20,8 @@
 <tr><td><a href="#edit.deindent.withIncomplete"><code>edit.deindent.withIncomplete</code></a></td><td>Deindent selected lines (including incomplete indent)</td><td><code>Shift+,</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../edit.ts#L43"><code>edit.delete</code></a></td><td>Delete</td><td><code>Alt+D</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../edit.ts#L44"><code>edit.delete-insert</code></a></td><td>Delete and switch to Insert</td><td><code>Alt+C</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
-<tr><td><a href="../edit.ts#L359"><code>edit.newLine.above.insert</code></a></td><td>Insert new line above and switch to insert</td><td><code>Shift+O</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
-<tr><td><a href="../edit.ts#L397"><code>edit.newLine.below.insert</code></a></td><td>Insert new line below and switch to insert</td><td><code>O</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
+<tr><td><a href="../edit.ts#L389"><code>edit.newLine.above.insert</code></a></td><td>Insert new line above and switch to insert</td><td><code>Shift+O</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
+<tr><td><a href="../edit.ts#L427"><code>edit.newLine.below.insert</code></a></td><td>Insert new line below and switch to insert</td><td><code>O</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../edit.ts#L36"><code>edit.paste.after</code></a></td><td>Paste after</td><td></td></tr>
 <tr><td><a href="../edit.ts#L38"><code>edit.paste.after.select</code></a></td><td>Paste after and select</td><td><code>P</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../edit.ts#L35"><code>edit.paste.before</code></a></td><td>Paste before</td><td></td></tr>
@@ -405,7 +405,7 @@ Default keybinding: `r` (kakoune: normal)
 
 <a name="edit.align" />
 
-### [`edit.align`](../edit.ts#L277-L290)
+### [`edit.align`](../edit.ts#L277-L285)
 
 Align selections.
 
@@ -420,7 +420,7 @@ Default keybinding: `&` (kakoune: normal)
 
 <a name="edit.copyIndentation" />
 
-### [`edit.copyIndentation`](../edit.ts#L305-L318)
+### [`edit.copyIndentation`](../edit.ts#L335-L348)
 
 Copy indentation.
 
@@ -435,7 +435,7 @@ Default keybinding: `a-&` (kakoune: normal)
 
 <a name="edit.newLine.above" />
 
-### [`edit.newLine.above`](../edit.ts#L347-L365)
+### [`edit.newLine.above`](../edit.ts#L377-L395)
 
 Insert new line above each selection.
 
@@ -457,7 +457,7 @@ Default keybinding: `s-a-o` (kakoune: normal)
 
 <a name="edit.newLine.below" />
 
-### [`edit.newLine.below`](../edit.ts#L385-L403)
+### [`edit.newLine.below`](../edit.ts#L415-L433)
 
 Insert new line below each selection.
 

--- a/src/commands/load-all.ts
+++ b/src/commands/load-all.ts
@@ -297,7 +297,7 @@ export const commands: Commands = function () {
     ),
     "dance.edit.align": new CommandDescriptor(
       "dance.edit.align",
-      (_, argument) => _.runAsync((_) => edit_align(_, _.selections, argument["fill"])),
+      (_, argument) => _.runAsync((_) => edit_align(_, argument["fill"])),
       CommandDescriptor.Flags.RequiresActiveEditor,
     ),
     "dance.edit.case.swap": new CommandDescriptor(

--- a/test/suite/commands/edit-align.md
+++ b/test/suite/commands/edit-align.md
@@ -64,15 +64,11 @@ selections are aligned by their selection active point
 
 ```
 Lorem ipsum dolor
-^^^^^ 0
+^^^^^ 0     ^^^^^ 2
       ^^^^^ 1
-            ^^^^^ 2
 consectetur adipiscing elit Morbi eget
-^^^^^^^^^^^ 3
-            ^^^^^^^^^^ 4
-                       ^^^^ 5
-                            ^^^^^ 6
-                                  ^^^^ 7
+^^^^^^^^^^^ 3          ^^^^ 5     ^^^^ 7
+            ^^^^^^^^^^ 4    ^^^^^ 6
 Aliquam erat
 ^^^^^^^ 8
         ^^^^ 9
@@ -85,18 +81,13 @@ Aliquam erat
 
 ```
       Lorem      ipsum dolor
-      ^^^^^ 0
+      ^^^^^ 0          ^^^^^ 2
                  ^^^^^ 1
-                       ^^^^^ 2
 consectetur adipiscing  elit Morbi eget
-^^^^^^^^^^^ 3
-            ^^^^^^^^^^ 4
-                        ^^^^ 5
-                             ^^^^^ 6
-                                   ^^^^ 7
+^^^^^^^^^^^ 3           ^^^^ 5     ^^^^ 7
+            ^^^^^^^^^^ 4     ^^^^^ 6
     Aliquam       erat
-    ^^^^^^^ 8
-                  ^^^^ 9
+    ^^^^^^^ 8     ^^^^ 9
 ```
 
 ## 3 align-inverted
@@ -107,16 +98,10 @@ consectetur adipiscing  elit Morbi eget
 
 ```
 Lorem       ipsum      dolor
-^^^^^ 0
-            ^^^^^ 1
-                       ^^^^^ 2
+^^^^^ 0     ^^^^^ 1    ^^^^^ 2
 consectetur adipiscing elit Morbi eget
-^^^^^^^^^^^ 3
-            ^^^^^^^^^^ 4
-                       ^^^^ 5
-                            ^^^^^ 6
-                                  ^^^^ 7
+^^^^^^^^^^^ 3          ^^^^ 5     ^^^^ 7
+            ^^^^^^^^^^ 4    ^^^^^ 6
 Aliquam     erat
-^^^^^^^ 8
-            ^^^^ 9
+^^^^^^^ 8   ^^^^ 9
 ```

--- a/test/suite/commands/edit-align.md
+++ b/test/suite/commands/edit-align.md
@@ -1,0 +1,122 @@
+# 1
+
+```
+foo:bar
+   ^ 0
+longfoo:bar
+       ^ 1
+foo2:longbar
+    ^ 2
+```
+
+## 1 align
+[up](#1)
+
+- .edit.align
+
+```
+foo    :bar
+       ^ 0
+longfoo:bar
+       ^ 1
+foo2   :longbar
+       ^ 2
+```
+
+
+# 2
+
+```
+selections are aligned by their selection active point
+ --> 97) lorem
+     ^^^ 0
+ --> 98) ipsum
+     ^^^ 1
+ --> 99) dolor
+     ^^^ 2
+ --> 100) sit
+     ^^^^ 3
+ --> 101) amet
+     ^^^^ 4
+```
+
+## 2 align
+[up](#2)
+
+- .edit.align
+
+```
+selections are aligned by their selection active point
+ -->  97) lorem
+      ^^^ 0
+ -->  98) ipsum
+      ^^^ 1
+ -->  99) dolor
+      ^^^ 2
+ --> 100) sit
+     ^^^^ 3
+ --> 101) amet
+     ^^^^ 4
+```
+
+
+# 3
+
+```
+Lorem ipsum dolor
+^^^^^ 0
+      ^^^^^ 1
+            ^^^^^ 2
+consectetur adipiscing elit Morbi eget
+^^^^^^^^^^^ 3
+            ^^^^^^^^^^ 4
+                       ^^^^ 5
+                            ^^^^^ 6
+                                  ^^^^ 7
+Aliquam erat
+^^^^^^^ 8
+        ^^^^ 9
+```
+
+## 3 align
+[up](#3)
+
+- .edit.align
+
+```
+      Lorem      ipsum dolor
+      ^^^^^ 0
+                 ^^^^^ 1
+                       ^^^^^ 2
+consectetur adipiscing  elit Morbi eget
+^^^^^^^^^^^ 3
+            ^^^^^^^^^^ 4
+                        ^^^^ 5
+                             ^^^^^ 6
+                                   ^^^^ 7
+    Aliquam       erat
+    ^^^^^^^ 8
+                  ^^^^ 9
+```
+
+## 3 align-inverted
+[up](#3)
+
+- .selections.changeDirection
+- .edit.align
+
+```
+Lorem       ipsum      dolor
+^^^^^ 0
+            ^^^^^ 1
+                       ^^^^^ 2
+consectetur adipiscing elit Morbi eget
+^^^^^^^^^^^ 3
+            ^^^^^^^^^^ 4
+                       ^^^^ 5
+                            ^^^^^ 6
+                                  ^^^^ 7
+Aliquam     erat
+^^^^^^^ 8
+            ^^^^ 9
+```

--- a/test/suite/commands/edit-align.test.ts
+++ b/test/suite/commands/edit-align.test.ts
@@ -1,0 +1,163 @@
+import * as vscode from "vscode";
+
+import { executeCommand, ExpectedDocument, groupTestsByParentName } from "../utils";
+
+suite("./test/suite/commands/edit-align.md", function () {
+  // Set up document.
+  let document: vscode.TextDocument,
+      editor: vscode.TextEditor;
+
+  this.beforeAll(async () => {
+    document = await vscode.workspace.openTextDocument({ language: "plaintext" });
+    editor = await vscode.window.showTextDocument(document);
+    editor.options.insertSpaces = true;
+    editor.options.tabSize = 2;
+
+    await executeCommand("dance.dev.setSelectionBehavior", { mode: "normal", value: "caret" });
+  });
+
+  this.afterAll(async () => {
+    await executeCommand("workbench.action.closeActiveEditor");
+  });
+
+  test("1 > align", async function () {
+    // Set-up document to be in expected initial state.
+    await ExpectedDocument.apply(editor, 6, String.raw`
+      foo:bar
+         ^ 0
+      longfoo:bar
+             ^ 1
+      foo2:longbar
+          ^ 2
+    `);
+
+    // Perform all operations.
+    await executeCommand("dance.edit.align");
+
+    // Ensure document is as expected.
+    ExpectedDocument.assertEquals(editor, "./test/suite/commands/edit-align.md:12:1", 6, String.raw`
+      foo    :bar
+             ^ 0
+      longfoo:bar
+             ^ 1
+      foo2   :longbar
+             ^ 2
+    `);
+  });
+
+  test("2 > align", async function () {
+    // Set-up document to be in expected initial state.
+    await ExpectedDocument.apply(editor, 6, String.raw`
+      selections are aligned by their selection active point
+       --> 97) lorem
+           ^^^ 0
+       --> 98) ipsum
+           ^^^ 1
+       --> 99) dolor
+           ^^^ 2
+       --> 100) sit
+           ^^^^ 3
+       --> 101) amet
+           ^^^^ 4
+    `);
+
+    // Perform all operations.
+    await executeCommand("dance.edit.align");
+
+    // Ensure document is as expected.
+    ExpectedDocument.assertEquals(editor, "./test/suite/commands/edit-align.md:43:1", 6, String.raw`
+      selections are aligned by their selection active point
+       -->  97) lorem
+            ^^^ 0
+       -->  98) ipsum
+            ^^^ 1
+       -->  99) dolor
+            ^^^ 2
+       --> 100) sit
+           ^^^^ 3
+       --> 101) amet
+           ^^^^ 4
+    `);
+  });
+
+  test("3 > align", async function () {
+    // Set-up document to be in expected initial state.
+    await ExpectedDocument.apply(editor, 6, String.raw`
+      Lorem ipsum dolor
+      ^^^^^ 0
+            ^^^^^ 1
+                  ^^^^^ 2
+      consectetur adipiscing elit Morbi eget
+      ^^^^^^^^^^^ 3
+                  ^^^^^^^^^^ 4
+                             ^^^^ 5
+                                  ^^^^^ 6
+                                        ^^^^ 7
+      Aliquam erat
+      ^^^^^^^ 8
+              ^^^^ 9
+    `);
+
+    // Perform all operations.
+    await executeCommand("dance.edit.align");
+
+    // Ensure document is as expected.
+    ExpectedDocument.assertEquals(editor, "./test/suite/commands/edit-align.md:81:1", 6, String.raw`
+            Lorem      ipsum dolor
+            ^^^^^ 0
+                       ^^^^^ 1
+                             ^^^^^ 2
+      consectetur adipiscing  elit Morbi eget
+      ^^^^^^^^^^^ 3
+                  ^^^^^^^^^^ 4
+                              ^^^^ 5
+                                   ^^^^^ 6
+                                         ^^^^ 7
+          Aliquam       erat
+          ^^^^^^^ 8
+                        ^^^^ 9
+    `);
+  });
+
+  test("3 > align-inverted", async function () {
+    // Set-up document to be in expected initial state.
+    await ExpectedDocument.apply(editor, 6, String.raw`
+      Lorem ipsum dolor
+      ^^^^^ 0
+            ^^^^^ 1
+                  ^^^^^ 2
+      consectetur adipiscing elit Morbi eget
+      ^^^^^^^^^^^ 3
+                  ^^^^^^^^^^ 4
+                             ^^^^ 5
+                                  ^^^^^ 6
+                                        ^^^^ 7
+      Aliquam erat
+      ^^^^^^^ 8
+              ^^^^ 9
+    `);
+
+    // Perform all operations.
+    await executeCommand("dance.selections.changeDirection");
+    await executeCommand("dance.edit.align");
+
+    // Ensure document is as expected.
+    ExpectedDocument.assertEquals(editor, "./test/suite/commands/edit-align.md:102:1", 6, String.raw`
+      Lorem       ipsum      dolor
+      ^^^^^ 0
+                  ^^^^^ 1
+                             ^^^^^ 2
+      consectetur adipiscing elit Morbi eget
+      ^^^^^^^^^^^ 3
+                  ^^^^^^^^^^ 4
+                             ^^^^ 5
+                                  ^^^^^ 6
+                                        ^^^^ 7
+      Aliquam     erat
+      ^^^^^^^ 8
+                  ^^^^ 9
+    `);
+  });
+
+  groupTestsByParentName(this);
+});

--- a/test/suite/commands/edit-align.test.ts
+++ b/test/suite/commands/edit-align.test.ts
@@ -84,15 +84,11 @@ suite("./test/suite/commands/edit-align.md", function () {
     // Set-up document to be in expected initial state.
     await ExpectedDocument.apply(editor, 6, String.raw`
       Lorem ipsum dolor
-      ^^^^^ 0
+      ^^^^^ 0     ^^^^^ 2
             ^^^^^ 1
-                  ^^^^^ 2
       consectetur adipiscing elit Morbi eget
-      ^^^^^^^^^^^ 3
-                  ^^^^^^^^^^ 4
-                             ^^^^ 5
-                                  ^^^^^ 6
-                                        ^^^^ 7
+      ^^^^^^^^^^^ 3          ^^^^ 5     ^^^^ 7
+                  ^^^^^^^^^^ 4    ^^^^^ 6
       Aliquam erat
       ^^^^^^^ 8
               ^^^^ 9
@@ -102,20 +98,15 @@ suite("./test/suite/commands/edit-align.md", function () {
     await executeCommand("dance.edit.align");
 
     // Ensure document is as expected.
-    ExpectedDocument.assertEquals(editor, "./test/suite/commands/edit-align.md:81:1", 6, String.raw`
+    ExpectedDocument.assertEquals(editor, "./test/suite/commands/edit-align.md:77:1", 6, String.raw`
             Lorem      ipsum dolor
-            ^^^^^ 0
+            ^^^^^ 0          ^^^^^ 2
                        ^^^^^ 1
-                             ^^^^^ 2
       consectetur adipiscing  elit Morbi eget
-      ^^^^^^^^^^^ 3
-                  ^^^^^^^^^^ 4
-                              ^^^^ 5
-                                   ^^^^^ 6
-                                         ^^^^ 7
+      ^^^^^^^^^^^ 3           ^^^^ 5     ^^^^ 7
+                  ^^^^^^^^^^ 4     ^^^^^ 6
           Aliquam       erat
-          ^^^^^^^ 8
-                        ^^^^ 9
+          ^^^^^^^ 8     ^^^^ 9
     `);
   });
 
@@ -123,15 +114,11 @@ suite("./test/suite/commands/edit-align.md", function () {
     // Set-up document to be in expected initial state.
     await ExpectedDocument.apply(editor, 6, String.raw`
       Lorem ipsum dolor
-      ^^^^^ 0
+      ^^^^^ 0     ^^^^^ 2
             ^^^^^ 1
-                  ^^^^^ 2
       consectetur adipiscing elit Morbi eget
-      ^^^^^^^^^^^ 3
-                  ^^^^^^^^^^ 4
-                             ^^^^ 5
-                                  ^^^^^ 6
-                                        ^^^^ 7
+      ^^^^^^^^^^^ 3          ^^^^ 5     ^^^^ 7
+                  ^^^^^^^^^^ 4    ^^^^^ 6
       Aliquam erat
       ^^^^^^^ 8
               ^^^^ 9
@@ -142,20 +129,14 @@ suite("./test/suite/commands/edit-align.md", function () {
     await executeCommand("dance.edit.align");
 
     // Ensure document is as expected.
-    ExpectedDocument.assertEquals(editor, "./test/suite/commands/edit-align.md:102:1", 6, String.raw`
+    ExpectedDocument.assertEquals(editor, "./test/suite/commands/edit-align.md:93:1", 6, String.raw`
       Lorem       ipsum      dolor
-      ^^^^^ 0
-                  ^^^^^ 1
-                             ^^^^^ 2
+      ^^^^^ 0     ^^^^^ 1    ^^^^^ 2
       consectetur adipiscing elit Morbi eget
-      ^^^^^^^^^^^ 3
-                  ^^^^^^^^^^ 4
-                             ^^^^ 5
-                                  ^^^^^ 6
-                                        ^^^^ 7
+      ^^^^^^^^^^^ 3          ^^^^ 5     ^^^^ 7
+                  ^^^^^^^^^^ 4    ^^^^^ 6
       Aliquam     erat
-      ^^^^^^^ 8
-                  ^^^^ 9
+      ^^^^^^^ 8   ^^^^ 9
     `);
   });
 


### PR DESCRIPTION
I added support for aligning over multiple columns, mimicking the behavior of kakoune when having more than one selection per line.