### PR TITLE
fix: allow more than 2 keybindings per command

### DIFF
--- a/meta.ts
+++ b/meta.ts
@@ -501,7 +501,7 @@ export function parseKeys(keys: string) {
     return [];
   }
 
-  return keys.replace("\n", ", ").split(/ *, (?=`)/g).map((keyString) => {
+  return keys.replace(/\n/g, ", ").split(/ *, (?=`)/g).map((keyString) => {
     const [,, rawKeybinding, rawMetadata] = /^(`+)(.+?)\1 \((.+?)\)$/.exec(keyString)!,
           keybinding = rawKeybinding.trim().replace(
             specialCharacterRegExp, (m) => (specialCharacterMapping as Record<string, string>)[m]),


### PR DESCRIPTION
Keybindings are currently limited to 2 per command because `replace` only replaces the first match when the 1st arg is a string. This seems unintentional.
`replaceAll` is not available in the ES version targeted, but we can use a regexp as the 1st argument to replace all occurrences.

This is useful when tinkering with the code to add new keybindings, [such as those from Helix "select" mode](https://github.com/71/dance/issues/299).