### PR TITLE
Escape key should close the autocomplete before switching to normal mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -3281,7 +3281,7 @@
       },
       {
         "key": "Escape",
-        "when": "editorTextFocus && dance.mode == 'insert'",
+        "when": "editorTextFocus && dance.mode == 'insert' && !suggestWidgetVisible",
         "title": "Set mode to Normal",
         "command": "dance.modes.set.normal"
       },


### PR DESCRIPTION
Currently, when in insert mode and the suggest panel(autocomplete) shows up, hitting escape will close the suggest panel and switch to normal mode.
This change allows the user to only close the suggest panel. To go to normal mode, the user would have to hit escape again.

A situation where this is helpful is when the suggest panel pop up together with github copilot suggestion. We want to stay in insert mode to accept github copilot suggestion