### PR TITLE
leap command highlighting rule improved.

### DIFF
--- a/src/commands/seek.ts
+++ b/src/commands/seek.ts
@@ -768,6 +768,8 @@ export async function leap(
         styledSet.deleteSelections(selections);
       }
     }
+    // clear unlabeled highlight
+    unlabeledSelectionsSet.clearSelections();
 
     // Listen to jumps to labels.
     let offset = 0;


### PR DESCRIPTION
clear unrelated unlabeledSelection highlight after 2ndChar was pressed.
## Comparison
When I type s to start an leap action, and type `a` as the 1st input:

 <image width=200
src="https://github.com/71/dance/assets/30321432/d444c8e3-a89b-4419-a797-8671522124c2"/>
Then, I wanna choose the position with prefix-"aj", so I type `j`.

<p>
 <image width=200 alt="Before this PR"
src="https://github.com/71/dance/assets/30321432/2e9a3de8-1e4c-4421-89bd-1d5c340f3f38"/>
 <image width=200 alt="After this PR"
src="https://github.com/71/dance/assets/30321432/4579bd7d-15ae-4817-a808-7fbc4982aabc"/>
</p>

Left: Before this PR; Right: After this PR.
As the pic shows, before this PR, there are some unrelated highlight remained, such as `"ab" "an" "as"`.
