### PR TITLE
Allow ordinary menus

### DIFF
--- a/package.build.ts
+++ b/package.build.ts
@@ -365,17 +365,15 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
                 type: "string",
               },
               menuType: {
-                anyOf: [
-                  {
-                    const: "palette",
-                    description: "A `palette` menu is a standard VSCode QuickPick menu, e.g. like the stock VSCode command palette."
-                  },
-                  {
-                    const: "hotkey",
-                    description: "A `hotkey` menu is used to give a menu and keybinds emulating Helix's multi-key Static Commands, e.g. [g]oto → [e]nd."
-                  }
+                type: "string",
+                enum: [
+                  "palette",
+                  "hotkey"
                 ],
-                description: 'meny type test',
+                markdownEnumDescriptions: [
+                  "A `palette` menu is a standard VSCode QuickPick menu, e.g. like the stock VSCode command palette.",
+                  "A `hotkey` menu is used to give a menu and keybinds emulating Kakoune's multi-key commands, e.g. [g]oto → [l]ine-end."
+                ],
                 default: "hotkey"
               },
               items: {

--- a/package.build.ts
+++ b/package.build.ts
@@ -386,7 +386,7 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
                       description: "Text shown in the menu.",
                     },
                     command: {
-                      type: "string",
+                      $ref: "vscode://schemas/keybindings#/definitions/commandNames",
                       description: "Command to execute on item selection.",
                     },
                     args: {

--- a/package.build.ts
+++ b/package.build.ts
@@ -368,13 +368,13 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
                 type: "string",
                 enum: [
                   "palette",
-                  "hotkey"
+                  "hotkey",
                 ],
                 markdownEnumDescriptions: [
                   "A `palette` menu is a standard VSCode QuickPick menu, e.g. like the stock VSCode command palette.",
-                  "A `hotkey` menu is used to give a menu and keybinds emulating Kakoune's multi-key commands, e.g. [g]oto → [l]ine-end."
+                  "A `hotkey` menu is used to give a menu and keybinds emulating Kakoune's multi-key commands, e.g. [g]oto → [l]ine-end.",
                 ],
-                default: "hotkey"
+                default: "hotkey",
               },
               items: {
                 type: "object",

--- a/package.build.ts
+++ b/package.build.ts
@@ -364,7 +364,7 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
               title: {
                 type: "string",
               },
-              menu_type: {
+              menuType: {
                 type: "string",
                 enum: ["hotkey", "palette"],
                 default: "hotkey"

--- a/package.build.ts
+++ b/package.build.ts
@@ -365,8 +365,17 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
                 type: "string",
               },
               menuType: {
-                type: "string",
-                enum: ["hotkey", "palette"],
+                anyOf: [
+                  {
+                    const: "palette",
+                    description: "A `palette` menu is a standard VSCode QuickPick menu, e.g. like the stock VSCode command palette."
+                  },
+                  {
+                    const: "hotkey",
+                    description: "A `hotkey` menu is used to give a menu and keybinds emulating Helix's multi-key Static Commands, e.g. [g]oto → [e]nd."
+                  }
+                ],
+                description: 'meny type test',
                 default: "hotkey"
               },
               items: {

--- a/package.build.ts
+++ b/package.build.ts
@@ -364,7 +364,7 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
               title: {
                 type: "string",
               },
-              menuType: {
+              type: {
                 type: "string",
                 enum: [
                   "palette",

--- a/package.build.ts
+++ b/package.build.ts
@@ -152,7 +152,7 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
     "source-map-support": "^0.5.21",
     "ts-loader": "^9.3.1",
     "ts-node": "^10.8.1",
-    "typescript": "^4.8.4",
+    "typescript": "^5.7.3",
     "unexpected": "^13.0.0",
     "vsce": "^2.7.0",
     "web-tree-sitter": "^0.20.8",

--- a/package.build.ts
+++ b/package.build.ts
@@ -364,6 +364,11 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
               title: {
                 type: "string",
               },
+              menu_type: {
+                type: "string",
+                enum: ["hotkey", "palette"],
+                default: "hotkey"
+              },
               items: {
                 type: "object",
                 additionalProperties: {

--- a/package.json
+++ b/package.json
@@ -448,7 +448,7 @@
               "title": {
                 "type": "string"
               },
-              "menuType": {
+              "type": {
                 "type": "string",
                 "enum": [
                   "palette",

--- a/package.json
+++ b/package.json
@@ -448,6 +448,14 @@
               "title": {
                 "type": "string"
               },
+              "menu_type": {
+                "type": "string",
+                "enum": [
+                  "hotkey",
+                  "palette"
+                ],
+                "default": "hotkey"
+              },
               "items": {
                 "type": "object",
                 "additionalProperties": {

--- a/package.json
+++ b/package.json
@@ -449,17 +449,15 @@
                 "type": "string"
               },
               "menuType": {
-                "anyOf": [
-                  {
-                    "const": "palette",
-                    "description": "A `palette` menu is a standard VSCode QuickPick menu, e.g. like the stock VSCode command palette."
-                  },
-                  {
-                    "const": "hotkey",
-                    "description": "A `hotkey` menu is used to give a menu and keybinds emulating Helix's multi-key Static Commands, e.g. [g]oto → [e]nd."
-                  }
+                "type": "string",
+                "enum": [
+                  "palette",
+                  "hotkey"
                 ],
-                "description": "meny type test",
+                "markdownEnumDescriptions": [
+                  "A `palette` menu is a standard VSCode QuickPick menu, e.g. like the stock VSCode command palette.",
+                  "A `hotkey` menu is used to give a menu and keybinds emulating Kakoune's multi-key commands, e.g. [g]oto → [l]ine-end."
+                ],
                 "default": "hotkey"
               },
               "items": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "source-map-support": "^0.5.21",
     "ts-loader": "^9.3.1",
     "ts-node": "^10.8.1",
-    "typescript": "^4.8.4",
+    "typescript": "^5.7.3",
     "unexpected": "^13.0.0",
     "vsce": "^2.7.0",
     "web-tree-sitter": "^0.20.8",

--- a/package.json
+++ b/package.json
@@ -448,12 +448,18 @@
               "title": {
                 "type": "string"
               },
-              "menu_type": {
-                "type": "string",
-                "enum": [
-                  "hotkey",
-                  "palette"
+              "menuType": {
+                "anyOf": [
+                  {
+                    "const": "palette",
+                    "description": "A `palette` menu is a standard VSCode QuickPick menu, e.g. like the stock VSCode command palette."
+                  },
+                  {
+                    "const": "hotkey",
+                    "description": "A `hotkey` menu is used to give a menu and keybinds emulating Helix's multi-key Static Commands, e.g. [g]oto → [e]nd."
+                  }
                 ],
+                "description": "meny type test",
                 "default": "hotkey"
               },
               "items": {

--- a/package.json
+++ b/package.json
@@ -470,7 +470,7 @@
                       "description": "Text shown in the menu."
                     },
                     "command": {
-                      "type": "string",
+                      "$ref": "vscode://schemas/keybindings#/definitions/commandNames",
                       "description": "Command to execute on item selection."
                     },
                     "args": {

--- a/src/api/menu.ts
+++ b/src/api/menu.ts
@@ -12,7 +12,7 @@ export interface Menu {
     *
     * `palette` menus are just stock-standard VSCode QuickPicks.
     */
-  readonly menuType?: 'hotkey' | 'palette'
+  readonly menuType?: "hotkey" | "palette"
   readonly items: Menu.Items;
 }
 
@@ -49,11 +49,11 @@ export function validateMenu(menu: Menu) {
     errors.push("menu title must be a string");
   }
 
-  if (menu.menuType !== undefined && menu.menuType !== 'hotkey' && menu.menuType !== 'palette') {
-    errors.push("menuType must be 'hotkey' (default) or 'palette'")
+  if (menu.menuType !== undefined && menu.menuType !== "hotkey" && menu.menuType !== "palette") {
+    errors.push("menuType must be 'hotkey' (default) or 'palette'");
   }
 
-  const isHotkey = (menu.menuType ?? 'hotkey') === 'hotkey';
+  const isHotkey = (menu.menuType ?? "hotkey") === "hotkey";
 
   for (const key in menu.items) {
     const item = menu.items[key],
@@ -123,10 +123,10 @@ export async function showMenu(
   const items = entries.map((x) => [x[0], x[1].text] as const);
 
   let choice: string | number;
-  if ((menu.menuType ?? 'hotkey') === 'hotkey') {
+  if ((menu.menuType ?? "hotkey") === "hotkey") {
     choice = await promptOne(items, (quickPick) => quickPick.title = menu.title);
   } else {
-    choice = await promptPalette(items, {title: menu.title});
+    choice = await promptPalette(items, { title: menu.title });
   }
 
   if (typeof choice === "string") {
@@ -207,28 +207,25 @@ export async function showMenuAfterDelay(
   }
 }
 
-function promptPalette(
+async function promptPalette(
   items: readonly (readonly [string, string])[],
   quickPickOptions: vscode.QuickPickOptions,
   context = Context.WithoutActiveEditor.current,
-): Thenable<number> {
-
-  return new Promise<number>(async (resolve, reject) => {
-    const result = await vscode.window.showQuickPick(
-      items.map(([label, description], i) => ({
-        label: label,
-        description: description,
-        _i: i
+): Promise<number> {
+  const result = await vscode.window.showQuickPick(
+    items.map(([label, description], i) => ({
+        label,
+        description,
+        _i: i,
       } satisfies vscode.QuickPickItem & {_i: number})),
-      {...quickPickOptions},
-      context.cancellationToken
-    );
-    if (result !== undefined) {
-      resolve(result._i)
-    } else {
-      reject(new CancellationError(CancellationError.Reason.PressedEscape))
-    }
-  });
+      { ...quickPickOptions },
+    context.cancellationToken,
+  );
+
+  if (result === undefined) {
+    throw new CancellationError(CancellationError.Reason.PressedEscape);
+  }
+  return result._i;
 }
 
 /**

--- a/src/api/menu.ts
+++ b/src/api/menu.ts
@@ -187,7 +187,7 @@ export async function showMenuAfterDelay(
       const pickedItem = menu.items[itemKeys],
             args = mergeArgs(pickedItem.args, additionalArgs);
 
-      return Context.WithoutActiveEditor.wrap(
+      await Context.WithoutActiveEditor.wrap(
         vscode.commands.executeCommand(pickedItem.command, ...args),
       );
     }
@@ -197,7 +197,8 @@ export async function showMenuAfterDelay(
     }
   } catch (e) {
     if (!currentContext.cancellationToken.isCancellationRequested) {
-      return showMenu(menu, additionalArgs, prefix);
+      await showMenu(menu, additionalArgs, prefix);
+      return;
     }
 
     throw e;

--- a/src/api/menu.ts
+++ b/src/api/menu.ts
@@ -184,12 +184,15 @@ export async function showMenuAfterDelay(
         continue;
       }
 
+      // found a match, run it and finish the loop
       const pickedItem = menu.items[itemKeys],
             args = mergeArgs(pickedItem.args, additionalArgs);
 
       await Context.WithoutActiveEditor.wrap(
         vscode.commands.executeCommand(pickedItem.command, ...args),
       );
+
+      return;
     }
 
     if (prefix !== undefined) {

--- a/src/api/menu.ts
+++ b/src/api/menu.ts
@@ -43,7 +43,7 @@ export function validateMenu(menu: Menu) {
     errors.push("menu title must be a string");
   }
 
-  if (menu.menu_type !== undefined && !(menu.menu_type == 'hotkey' || menu.menu_type == 'palette')) {
+  if (menu.menu_type !== undefined && menu.menu_type !== 'hotkey' && menu.menu_type !== 'palette') {
     errors.push("menu_type must be 'hotkey' (default) or 'palette'")
   }
 

--- a/src/api/menu.ts
+++ b/src/api/menu.ts
@@ -6,6 +6,12 @@ import { CancellationError } from "./errors";
 
 export interface Menu {
   readonly title?: string;
+  /**
+    * `hotkey` menus are built into a tree of hotkey characters, to
+    * implement kakoune's multi-key commands/menus, like [g]oto → [l]ine-end.
+    *
+    * `palette` menus are just stock-standard VSCode QuickPicks.
+    */
   readonly menuType?: 'hotkey' | 'palette'
   readonly items: Menu.Items;
 }
@@ -117,7 +123,7 @@ export async function showMenu(
   const items = entries.map((x) => [x[0], x[1].text] as const);
 
   let choice: string | number;
-  if ((menu.menuType ?? 'hotkey') == 'hotkey') {
+  if ((menu.menuType ?? 'hotkey') === 'hotkey') {
     choice = await promptOne(items, (quickPick) => quickPick.title = menu.title);
   } else {
     choice = await promptPalette(items, {title: menu.title});

--- a/src/api/menu.ts
+++ b/src/api/menu.ts
@@ -12,7 +12,7 @@ export interface Menu {
     *
     * `palette` menus are just stock-standard VSCode QuickPicks.
     */
-  readonly menuType?: "hotkey" | "palette"
+  readonly type?: "hotkey" | "palette"
   readonly items: Menu.Items;
 }
 
@@ -49,11 +49,11 @@ export function validateMenu(menu: Menu) {
     errors.push("menu title must be a string");
   }
 
-  if (menu.menuType !== undefined && menu.menuType !== "hotkey" && menu.menuType !== "palette") {
-    errors.push("menuType must be 'hotkey' (default) or 'palette'");
+  if (menu.type !== undefined && menu.type !== "hotkey" && menu.type !== "palette") {
+    errors.push("menu.type must be 'hotkey' (default) or 'palette'");
   }
 
-  const isHotkey = (menu.menuType ?? "hotkey") === "hotkey";
+  const isHotkey = (menu.type ?? "hotkey") === "hotkey";
 
   for (const key in menu.items) {
     const item = menu.items[key],
@@ -123,7 +123,7 @@ export async function showMenu(
   const items = entries.map((x) => [x[0], x[1].text] as const);
 
   let choice: string | number;
-  if ((menu.menuType ?? "hotkey") === "hotkey") {
+  if ((menu.type ?? "hotkey") === "hotkey") {
     choice = await promptOne(items, (quickPick) => quickPick.title = menu.title);
   } else {
     choice = await promptPalette(items, { title: menu.title });

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -516,7 +516,8 @@ async function insertLinesNativelyAndCopySelections(
   Selections.updateByIndex(prepareSelectionForLineInsertion);
 
   if (repetitions === 1) {
-    return vscode.commands.executeCommand(command);
+    await vscode.commands.executeCommand(command);
+    return;
   }
 
   const isLastCharacterAt = [] as boolean[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,10 +2730,10 @@ typed-rest-client@^1.8.4:
     tunnel "0.0.6"
     underscore "^1.12.1"
 
-typescript@^4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@^5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Heya, thanks for maintaining this.

When playing with Strackeror's great Helix mode contribution, I was having trouble getting a command-hx menu to feel right due to the single hot key system. E.g. distilled to a three item menu, "fmt / Format", "w / Write", and "wbc / Write and Close", `w` and `wbc` can't be distinguished in the current system.

As a proof of concept, I wondered if menus could have a `menu_type: "hotkey"` (current behaviour, and default) or alternatively a `menu_type: "palette"`, which is just a stock-standard vscode quickpick. Palette menus don't have the hotkey system but can just use vscode's already great type/select system which I've been using locally quite happily.

Demo:

https://github.com/user-attachments/assets/5729f88b-8efd-4492-a3a9-9f5532bff41c

<details><summary>From menus config:</summary>

```json5
    "dance.menus": {
        "leader-hx": {
            "title": "Space",
            "items": {
                "f": {
                    "text": "Open file picker",
                    "command": "workbench.action.quickOpen"
                }
            }
        },
        "command-hx": {
            "title": "Helix command mode",
            "menu_type": "palette",
            "items": {
                "fmt": {
                    "text": "format",
                    "command": "editor.action.formatDocument"
                },
                "w": {
                    "text": "write",
                    "command": "workbench.action.files.save"
                },
                // "wbc": {
                //     "text": "write-buffer-close",
                //     "command": "dance.run",
                //     "args": [
                //         {
                //             "commands": [
                //                 "workbench.action.files.save",
                //                 "workbench.action.closeeditor"
                //             ]
                //         }
                //     ]
                // }
            }
        }
    },
```

</details>

This probably isn't wired up the best way, but was hoping to get some feedback on if this would be accepted in principal or not before fiddling further.

Thanks!