### PR TITLE
Custom formatting of display name

### DIFF
--- a/package.json
+++ b/package.json
@@ -930,6 +930,21 @@
             "Selections are anchored to characters, like Kakoune; that is, they are positioned *on* characters, and therefore cannot be empty. Additionally, one-character selections will behave as if they were non-directional, like Kakoune."
           ],
           "markdownDeprecationMessage": "Built-in modes are deprecated. Use `#dance.modes#` instead."
+        },
+        "dance.activeModeDisplayStyle": {
+          "enum": [
+            "as-is",
+            "uppercase",
+            "lowercase"
+
+          ],
+          "default": "as-is",
+          "description": "Controls how the active mode is formmated in the status bar.",
+          "enumDescriptions": [
+            "Display the name with its original formmatting.",
+            "Convert the name to uppercase.",
+            "Convert the name to lowercase."
+          ]
         }
       }
     },

--- a/src/state/editors.ts
+++ b/src/state/editors.ts
@@ -234,12 +234,24 @@ export class PerEditorState implements vscode.Disposable {
   public notifyDidBecomeActive() {
     const { editor, mode } = this;
 
-    this.extension.statusBar.activeModeSegment.setContent(mode.name);
+    this.extension.statusBar.activeModeSegment.setContent(this._formatDisplayName(mode.name));
 
     editor.options.lineNumbers = mode.lineNumbers;
     editor.options.cursorStyle = mode.cursorStyle;
 
     return vscode.commands.executeCommand("setContext", extensionName + ".mode", mode.name);
+  }
+  private _formatDisplayName(modeName: string) {
+    switch (vscode.workspace.getConfiguration(extensionName)
+      .get<string>("activeModeDisplayStyle")) {
+    case "uppercase":
+      return modeName.toUpperCase();
+    case "lowercase":
+      return modeName.toLowerCase();
+    case "as-is":
+    default:
+      return modeName;
+    }
   }
 
   /**


### PR DESCRIPTION
I always wish I could show the mode in the status bar in uppercase so that I notice it more. This is how Vim does it, I believe. Rather than making a simple boolean, I made it an enum so other display modes can be added in the future. This would be helpful for someone who has a lot of custom modes and wants to change how they're displayed.

This is my first time working on a VSCode extension, so feedback is very welcome. I wasn't sure how to build. I ran `npm i`, but it change the yarn file and added far more to `package-lock.json` than I expected, so I reverted it. I also didn't touch any validation of the setting (although I did add a `default` to the switch case to handle unrecognized values).