### PR TITLE
Unify build version of helix extension

### DIFF
--- a/extensions/helix/package.build.ts
+++ b/extensions/helix/package.build.ts
@@ -50,8 +50,8 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
   scripts: {
     "package": "vsce package --allow-star-activation --follow-symlinks",
     "publish": "vsce publish --allow-star-activation --follow-symlinks",
-    "package:pre": `vsce package --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json --follow-symlinks ${preReleaseVersion}`,
-    "publish:pre": `vsce publish --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json --follow-symlinks ${preReleaseVersion}`,
+    "package:pre": `vsce package --allow-star-activation --follow-symlinks --pre-release --no-git-tag-version --no-update-package-json ${preReleaseVersion}`,
+    "publish:pre": `vsce publish --allow-star-activation --follow-symlinks --pre-release --no-git-tag-version --no-update-package-json ${preReleaseVersion}`,
   },
 
   contributes: {

--- a/extensions/helix/package.build.ts
+++ b/extensions/helix/package.build.ts
@@ -2,12 +2,9 @@
 // ============================================================================
 
 import { Builder, generateIgnoredKeybinds } from "../../meta";
+import { version, preReleaseVersion } from "../../package.build";
 import * as fs from "fs/promises";
 import { extensionId } from "../../src/utils/constants";
-
-const version = "0.1.0",
-      preRelease = 1,
-      preReleaseVersion = `${version}-pre${preRelease}`;
 
 export const pkg = (modules: Builder.ParsedModule[]) => ({
 

--- a/extensions/helix/package.json
+++ b/extensions/helix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dance-helix-keybindings",
   "description": "Helix keybindings for Dance",
-  "version": "0.1.0",
+  "version": "0.5.15",
   "license": "ISC",
   "extensionDependencies": [
     "gregoire.dance"
@@ -38,8 +38,8 @@
   "scripts": {
     "package": "vsce package --allow-star-activation --follow-symlinks",
     "publish": "vsce publish --allow-star-activation --follow-symlinks",
-    "package:pre": "vsce package --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json --follow-symlinks 0.1.0-pre1",
-    "publish:pre": "vsce publish --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json --follow-symlinks 0.1.0-pre1"
+    "package:pre": "vsce package --allow-star-activation --follow-symlinks --pre-release --no-git-tag-version --no-update-package-json 0.5.15-pre1",
+    "publish:pre": "vsce publish --allow-star-activation --follow-symlinks --pre-release --no-git-tag-version --no-update-package-json 0.5.15-pre1"
   },
   "contributes": {
     "configurationDefaults": {

--- a/package.build.ts
+++ b/package.build.ts
@@ -77,8 +77,9 @@ const selectionDecorationType = {
 // Package information
 // ============================================================================
 
-const version = "0.5.15",
-      preRelease = 1;
+export const version = "0.5.15",
+             preRelease = 1,
+             preReleaseVersion = `${version}-pre${preRelease}`;
 
 export const pkg = (modules: Builder.ParsedModule[]) => ({
 
@@ -127,8 +128,8 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
     "vscode:prepublish": "yarn run generate && yarn run compile && yarn run compile-web",
     "package": "vsce package --allow-star-activation",
     "publish": "vsce publish --allow-star-activation",
-    "package:pre": `vsce package --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json ${version.replace(/\d+$/, "$&" + preRelease.toString().padStart(3, "0"))}`,
-    "publish:pre": `vsce publish --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json ${version.replace(/\d+$/, "$&" + preRelease.toString().padStart(3, "0"))}`,
+    "package:pre": `vsce package --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json ${preReleaseVersion}`,
+    "publish:pre": `vsce publish --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json ${preReleaseVersion}`,
 
     "package-helix:pre": `cd extensions/helix && yarn run package:pre`,
     "publish-helix:pre": `cd extensions/helix && yarn run publish:pre`,

--- a/package.build.ts
+++ b/package.build.ts
@@ -131,8 +131,10 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
     "package:pre": `vsce package --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json ${preReleaseVersion}`,
     "publish:pre": `vsce publish --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json ${preReleaseVersion}`,
 
-    "package-helix:pre": `cd extensions/helix && yarn run package:pre`,
-    "publish-helix:pre": `cd extensions/helix && yarn run publish:pre`,
+    "package-helix": "cd extensions/helix && vsce package --allow-star-activation --follow-symlinks",
+    "publish-helix": "cd extensions/helix && vsce publish --allow-star-activation --follow-symlinks",
+    "package-helix:pre": `cd extensions/helix && vsce package --allow-star-activation --follow-symlinks --pre-release --no-git-tag-version --no-update-package-json ${preReleaseVersion}`,
+    "publish-helix:pre": `cd extensions/helix && vsce publish --allow-star-activation --follow-symlinks --pre-release --no-git-tag-version --no-update-package-json ${preReleaseVersion}`,
   },
 
   devDependencies: {

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
     "vscode:prepublish": "yarn run generate && yarn run compile && yarn run compile-web",
     "package": "vsce package --allow-star-activation",
     "publish": "vsce publish --allow-star-activation",
-    "package:pre": "vsce package --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json 0.5.15001",
-    "publish:pre": "vsce publish --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json 0.5.15001",
-    "package-helix:pre": "cd extensions/helix && yarn run package:pre",
-    "publish-helix:pre": "cd extensions/helix && yarn run publish:pre"
+    "package:pre": "vsce package --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json 0.5.15-pre1",
+    "publish:pre": "vsce publish --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json 0.5.15-pre1",
+    "package-helix": "cd extensions/helix && vsce package --allow-star-activation --follow-symlinks",
+    "publish-helix": "cd extensions/helix && vsce publish --allow-star-activation --follow-symlinks",
+    "package-helix:pre": "cd extensions/helix && vsce package --allow-star-activation --follow-symlinks --pre-release --no-git-tag-version --no-update-package-json 0.5.15-pre1",
+    "publish-helix:pre": "cd extensions/helix && vsce publish --allow-star-activation --follow-symlinks --pre-release --no-git-tag-version --no-update-package-json 0.5.15-pre1"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",


### PR DESCRIPTION
and basically style update to unify all build command to vsce from yarn as `--follow-synlinks` option is only support in `vsce {package,publish,ls}`