### PR TITLE
[WIP / Please Comment] Remove Asynchrony / Fix Races? #343

### DIFF
--- a/src/state/extension.ts
+++ b/src/state/extension.ts
@@ -398,15 +398,15 @@ export class Extension implements vscode.Disposable {
    * Runs the given async function, displaying an error message and returning
    * the specified value if it throws an exception during its execution.
    */
-  public async runPromiseSafely<T>(
-    f: () => Thenable<T>,
+  public runPromiseSafely<T>(
+    f: () => T,
     errorValue: () => T,
     errorMessage: (error: any) => string,
   ) {
     this.dismissErrorMessage();
 
     try {
-      return await f();
+      return f();
     } catch (e) {
       if (!(e instanceof CancellationError)) {
         this.showDismissibleErrorMessage(errorMessage(e));

--- a/test/suite/commands/synchrony.md
+++ b/test/suite/commands/synchrony.md
@@ -1,0 +1,227 @@
+# 1
+
+> behavior <- character
+
+```
+
+^ 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+b
+```
+
+## 1 down
+[up](#1)
+
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+- .select.down.jump
+
+```
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+b
+^ 0
+```

--- a/test/suite/commands/synchrony.test.ts
+++ b/test/suite/commands/synchrony.test.ts
@@ -1,0 +1,252 @@
+import * as vscode from "vscode";
+
+import { executeCommand, ExpectedDocument, groupTestsByParentName } from "../utils";
+
+suite("./test/suite/commands/synchrony.md", function () {
+  // Set up document.
+  let document: vscode.TextDocument,
+      editor: vscode.TextEditor;
+
+  this.beforeAll(async () => {
+    document = await vscode.workspace.openTextDocument({ language: "plaintext" });
+    editor = await vscode.window.showTextDocument(document);
+    editor.options.insertSpaces = true;
+    editor.options.tabSize = 2;
+
+    await executeCommand("dance.dev.setSelectionBehavior", { mode: "normal", value: "caret" });
+  });
+
+  this.afterAll(async () => {
+    await executeCommand("workbench.action.closeActiveEditor");
+  });
+
+  test("1 > down", async function () {
+    // Set-up document to be in expected initial state.
+    await ExpectedDocument.apply(editor, 6, String.raw`
+
+      ^ 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      b
+    `);
+
+    // Perform all operations.
+    await executeCommand("dance.dev.setSelectionBehavior", { mode: "normal", value: "character" });
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.select.down.jump");
+    await executeCommand("dance.dev.setSelectionBehavior", { mode: "normal", value: "caret" });
+
+    // Ensure document is as expected.
+    ExpectedDocument.assertEquals(editor, "./test/suite/commands/synchrony.md:79:1", 6, String.raw`
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      b
+      ^ 0
+    `);
+  });
+
+  groupTestsByParentName(this);
+});

--- a/test/suite/utils.ts
+++ b/test/suite/utils.ts
@@ -82,9 +82,9 @@ export async function executeCommand(command: string, ...args: readonly any[]) {
   const extension =
     vscode.extensions.getExtension<{ extension: Extension }>("gregoire.dance")!.exports.extension;
 
-  extension.runPromiseSafely = async (f) => {
+  extension.runPromiseSafely = (f) => {
     try {
-      return await f();
+      return f();
     } catch (e) {
       error = e;
       throw e;


### PR DESCRIPTION
Hi 71 -

I took the liberty of checking out the code and seeing if I could address this keypresses racing issue (#343). The first thing I noticed is that the very start of the keypress handling stack is asynchronous. What I've learned is that `await`ing a concrete value *still yields to the scheduler*. So, we should avoid asyncs or awaits in the keypress stack.

As a first pass, I simply *removed* the await here. Because of the use of the unknown type, I can't identify which values were promises and which were concrete, but it passes the entire test suite and my initial experimentation hasn't indicated any problems yet. I thought maybe you would be able to comment on where asynchrony is actually needed.

If we do need to maintain asynchrony, it should be easy to use a conditional to either await or return; this may require restructing a little bit in the very top of the stack where we install handlers to the extension.

I'm going to try building this and installing it on my main VSCode to see if it fixes the problem and/or causes new problems, since it's extremely difficult to properly test this behavior. Can you let me know if I'm on the right track?

Thank you!