### PR TITLE
fix: jump vertically by page folding bug

### DIFF
--- a/src/commands/select.ts
+++ b/src/commands/select.ts
@@ -68,12 +68,15 @@ export function vertically(
 ) {
   // Adjust repetitions if a `by` parameter is given.
   if (by !== undefined) {
-    const visibleRange = _.editor.visibleRanges[0];
+    const visibleLines = _.editor.visibleRanges.reduce(
+      (lines, range) => lines + (range.end.line - range.start.line),
+      0,
+    );
 
     if (by === "page") {
-      repetitions *= visibleRange.end.line - visibleRange.start.line;
+      repetitions *= visibleLines;
     } else if (by === "halfPage") {
-      repetitions *= ((visibleRange.end.line - visibleRange.start.line) / 2) | 0;
+      repetitions *= (visibleLines / 2) | 0;
     }
   }
 


### PR DESCRIPTION
Before this change, the jump vertically by page / halfPage fails when  the first visible range is near a folded region. This solution  considers all visible ranges, rather than just the first to calculate  the page height. Alternatively, there can be a minimum number of lines  to consider a "page", or the largest unfolded region could be used, or  the difference between the first region's start and the last region's  end.