### PR TITLE
feat: Add the rest of match mode to Helix keymap

### DIFF
--- a/extensions/helix/package.build.ts
+++ b/extensions/helix/package.build.ts
@@ -69,6 +69,7 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
       "dance.defaultMode": "helix/normal",
       "dance.modes": {
         "helix/insert": {
+          lineNumbers: "on",
           onLeaveMode: [
             [".selections.save", {
               register: " insert",
@@ -76,10 +77,12 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
           ],
         },
         "helix/select": {
+          lineNumbers: "on",
           cursorStyle: "block",
           selectionBehavior: "character",
         },
         "helix/normal": {
+          lineNumbers: "relative",
           cursorStyle: "block",
           selectionBehavior: "character",
           decorations: {
@@ -116,6 +119,9 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
             "m": { command: "dance.seek.enclosing", text: "Goto matching bracket" },
             "a": { command: "dance.openMenu", args: [{ menu: "object", title: "Match around" }], text: "Select around object" },
             "i": { command: "dance.openMenu", args: [{ menu: "object", title: "Match inside", pass: [{ inner: true }] }], text: "Select inside object" },
+            "s": { command: "dance.openMenu", args: [{ menu: "surround", title: "Surround object" }], text: "Surround object" },
+            "r": { command: "dance.openMenu", args: [{ menu: "resurround", title: "Resurround object" }], text: "Resurround object" },
+            "d": { command: "dance.openMenu", args: [{ menu: "unsurround", title: "Unsurround object" }], text: "Unsurround object" },
           },
         },
 
@@ -136,6 +142,100 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
             "!": { command, text: "custom object desc" },
           }))(),
         },
+
+      surround: {
+        title: "Surround object with...",
+        items: (() => {
+          const pairs = {
+            "()": "parenthesis block",
+            "{}": "braces block",
+            "[]": "brackets block",
+            "<>": "angle block",
+            '"': "double quote string",
+            "'": "single quote string",
+            "`": "grave quote string",
+          };
+
+          return Object.fromEntries(
+            Object.entries(pairs)
+              .map(([key, description]) => {
+                const [open, close] = key.length === 1 ? [key, key] : Array.from(key);
+                const commands = [
+                  { command: "dance.edit.insert", args: { shift: "extend", text: open, where: "start" } },
+                  { command: "dance.edit.insert", args: { shift: "extend", text: close, where: "end" } },
+                ];
+
+                return [key, { command: "dance.run", args: { commands }, text: description }];
+              }),
+          );
+        })(),
+      },
+
+      resurround: {
+        title: "Resurround object...",
+        items: (() => {
+          const pairs = {
+            "()": "parenthesis block",
+            "{}": "braces block",
+            "[]": "brackets block",
+            "<>": "angle block",
+            '"': "double quote string",
+            "'": "single quote string",
+            "`": "grave quote string",
+          };
+          const enclosing = ["\\(", "\\)", "\\{", "\\}", "\\[", "\\]", "<", ">", '"', '"', "'", "'", "`", "`"];
+
+          return Object.fromEntries(
+            Object.entries(pairs)
+              .map(([key, description]) => {
+                const [open, close] = key.length === 1 ? [key, key] : Array.from(key);
+                const commands = [
+                  { command: "dance.seek.enclosing", args: { pairs: enclosing } },
+                  { command: "dance.edit.insert", args: { text: open, where: "start" } },
+                  { command: "dance.edit.insert", args: { text: close, where: "end" } },
+                  { command: "dance.selections.reduce.edges" },
+                  { command: "dance.edit.delete" },
+                  { command: "dance.selections.clear.secondary" },
+                ];
+
+                return [key, { command: "dance.run", args: { commands }, text: description }];
+              }),
+          );
+        })(),
+      },
+
+      unsurround: {
+        title: "Unsurround object...",
+        items: (() => {
+          const pairs = {
+            "m": { description: "enclosing pair", input: undefined },
+            "()": { description: "parenthesis block", input: "\\((?#inner)\\)" },
+            "{}": { description: "braces block", input: "\\{(?#inner)\\}" },
+            "[]": { description: "brackets block", input: "\\[(?#inner)\\]" },
+            "<>": { description: "angle block", input: "<(?#inner)>" },
+            '"': { description: "double quote string", input: '(?#noescape)"(?#inner)(?#noescape)"' },
+            "'": { description: "single quote string", input: "(?#noescape)'(?#inner)(?#noescape)'" },
+            "`": { description: "grave quote string", input: "(?#noescape)`(?#inner)(?#noescape)`" },
+          };
+
+          return Object.fromEntries(
+            Object.entries(pairs)
+              .map(([key, { description, input }]) => {
+                const seekCommand = input === undefined
+                  ? { command: "dance.seek.enclosing" }
+                  : { command: "dance.seek.object", args: [{ input }] };
+                const commands = [
+                  seekCommand,
+                    { command: "dance.selections.reduce.edges" },
+                    { command: "dance.edit.delete" },
+                    { command: "dance.selections.clear.secondary" },
+                ];
+
+                return [key, { command: "dance.run", args: { commands }, text: description }];
+              }),
+          );
+        })(),
+      },
 
         view: {
           "title": "View",

--- a/extensions/helix/package.build.ts
+++ b/extensions/helix/package.build.ts
@@ -226,9 +226,9 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
                   : { command: "dance.seek.object", args: [{ input }] };
                 const commands = [
                   seekCommand,
-                    { command: "dance.selections.reduce.edges" },
-                    { command: "dance.edit.delete" },
-                    { command: "dance.selections.clear.secondary" },
+                  { command: "dance.selections.reduce.edges" },
+                  { command: "dance.edit.delete" },
+                  { command: "dance.selections.clear.secondary" },
                 ];
 
                 return [key, { command: "dance.run", args: { commands }, text: description }];

--- a/extensions/helix/package.json
+++ b/extensions/helix/package.json
@@ -54,6 +54,7 @@
       "dance.defaultMode": "helix/normal",
       "dance.modes": {
         "helix/insert": {
+          "lineNumbers": "on",
           "onLeaveMode": [
             [
               ".selections.save",
@@ -64,10 +65,12 @@
           ]
         },
         "helix/select": {
+          "lineNumbers": "on",
           "cursorStyle": "block",
           "selectionBehavior": "character"
         },
         "helix/normal": {
+          "lineNumbers": "relative",
           "cursorStyle": "block",
           "selectionBehavior": "character",
           "decorations": {
@@ -143,6 +146,36 @@
                 }
               ],
               "text": "Select inside object"
+            },
+            "s": {
+              "command": "dance.openMenu",
+              "args": [
+                {
+                  "menu": "surround",
+                  "title": "Surround object"
+                }
+              ],
+              "text": "Surround object"
+            },
+            "r": {
+              "command": "dance.openMenu",
+              "args": [
+                {
+                  "menu": "resurround",
+                  "title": "Resurround object"
+                }
+              ],
+              "text": "Resurround object"
+            },
+            "d": {
+              "command": "dance.openMenu",
+              "args": [
+                {
+                  "menu": "unsurround",
+                  "title": "Unsurround object"
+                }
+              ],
+              "text": "Unsurround object"
             }
           }
         },
@@ -251,6 +284,748 @@
             "!": {
               "command": "dance.seek.object",
               "text": "custom object desc"
+            }
+          }
+        },
+        "surround": {
+          "title": "Surround object with...",
+          "items": {
+            "()": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": "(",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": ")",
+                      "where": "end"
+                    }
+                  }
+                ]
+              },
+              "text": "parenthesis block"
+            },
+            "{}": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": "{",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": "}",
+                      "where": "end"
+                    }
+                  }
+                ]
+              },
+              "text": "braces block"
+            },
+            "[]": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": "[",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": "]",
+                      "where": "end"
+                    }
+                  }
+                ]
+              },
+              "text": "brackets block"
+            },
+            "<>": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": "<",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": ">",
+                      "where": "end"
+                    }
+                  }
+                ]
+              },
+              "text": "angle block"
+            },
+            "\"": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": "\"",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": "\"",
+                      "where": "end"
+                    }
+                  }
+                ]
+              },
+              "text": "double quote string"
+            },
+            "'": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": "'",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": "'",
+                      "where": "end"
+                    }
+                  }
+                ]
+              },
+              "text": "single quote string"
+            },
+            "`": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": "`",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "shift": "extend",
+                      "text": "`",
+                      "where": "end"
+                    }
+                  }
+                ]
+              },
+              "text": "grave quote string"
+            }
+          }
+        },
+        "resurround": {
+          "title": "Resurround object...",
+          "items": {
+            "()": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.enclosing",
+                    "args": {
+                      "pairs": [
+                        "\\(",
+                        "\\)",
+                        "\\{",
+                        "\\}",
+                        "\\[",
+                        "\\]",
+                        "<",
+                        ">",
+                        "\"",
+                        "\"",
+                        "'",
+                        "'",
+                        "`",
+                        "`"
+                      ]
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": "(",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": ")",
+                      "where": "end"
+                    }
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "parenthesis block"
+            },
+            "{}": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.enclosing",
+                    "args": {
+                      "pairs": [
+                        "\\(",
+                        "\\)",
+                        "\\{",
+                        "\\}",
+                        "\\[",
+                        "\\]",
+                        "<",
+                        ">",
+                        "\"",
+                        "\"",
+                        "'",
+                        "'",
+                        "`",
+                        "`"
+                      ]
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": "{",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": "}",
+                      "where": "end"
+                    }
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "braces block"
+            },
+            "[]": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.enclosing",
+                    "args": {
+                      "pairs": [
+                        "\\(",
+                        "\\)",
+                        "\\{",
+                        "\\}",
+                        "\\[",
+                        "\\]",
+                        "<",
+                        ">",
+                        "\"",
+                        "\"",
+                        "'",
+                        "'",
+                        "`",
+                        "`"
+                      ]
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": "[",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": "]",
+                      "where": "end"
+                    }
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "brackets block"
+            },
+            "<>": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.enclosing",
+                    "args": {
+                      "pairs": [
+                        "\\(",
+                        "\\)",
+                        "\\{",
+                        "\\}",
+                        "\\[",
+                        "\\]",
+                        "<",
+                        ">",
+                        "\"",
+                        "\"",
+                        "'",
+                        "'",
+                        "`",
+                        "`"
+                      ]
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": "<",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": ">",
+                      "where": "end"
+                    }
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "angle block"
+            },
+            "\"": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.enclosing",
+                    "args": {
+                      "pairs": [
+                        "\\(",
+                        "\\)",
+                        "\\{",
+                        "\\}",
+                        "\\[",
+                        "\\]",
+                        "<",
+                        ">",
+                        "\"",
+                        "\"",
+                        "'",
+                        "'",
+                        "`",
+                        "`"
+                      ]
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": "\"",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": "\"",
+                      "where": "end"
+                    }
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "double quote string"
+            },
+            "'": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.enclosing",
+                    "args": {
+                      "pairs": [
+                        "\\(",
+                        "\\)",
+                        "\\{",
+                        "\\}",
+                        "\\[",
+                        "\\]",
+                        "<",
+                        ">",
+                        "\"",
+                        "\"",
+                        "'",
+                        "'",
+                        "`",
+                        "`"
+                      ]
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": "'",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": "'",
+                      "where": "end"
+                    }
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "single quote string"
+            },
+            "`": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.enclosing",
+                    "args": {
+                      "pairs": [
+                        "\\(",
+                        "\\)",
+                        "\\{",
+                        "\\}",
+                        "\\[",
+                        "\\]",
+                        "<",
+                        ">",
+                        "\"",
+                        "\"",
+                        "'",
+                        "'",
+                        "`",
+                        "`"
+                      ]
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": "`",
+                      "where": "start"
+                    }
+                  },
+                  {
+                    "command": "dance.edit.insert",
+                    "args": {
+                      "text": "`",
+                      "where": "end"
+                    }
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "grave quote string"
+            }
+          }
+        },
+        "unsurround": {
+          "title": "Unsurround object...",
+          "items": {
+            "m": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.enclosing"
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "enclosing pair"
+            },
+            "()": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.object",
+                    "args": [
+                      {
+                        "input": "\\((?#inner)\\)"
+                      }
+                    ]
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "parenthesis block"
+            },
+            "{}": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.object",
+                    "args": [
+                      {
+                        "input": "\\{(?#inner)\\}"
+                      }
+                    ]
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "braces block"
+            },
+            "[]": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.object",
+                    "args": [
+                      {
+                        "input": "\\[(?#inner)\\]"
+                      }
+                    ]
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "brackets block"
+            },
+            "<>": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.object",
+                    "args": [
+                      {
+                        "input": "<(?#inner)>"
+                      }
+                    ]
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "angle block"
+            },
+            "\"": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.object",
+                    "args": [
+                      {
+                        "input": "(?#noescape)\"(?#inner)(?#noescape)\""
+                      }
+                    ]
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "double quote string"
+            },
+            "'": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.object",
+                    "args": [
+                      {
+                        "input": "(?#noescape)'(?#inner)(?#noescape)'"
+                      }
+                    ]
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "single quote string"
+            },
+            "`": {
+              "command": "dance.run",
+              "args": {
+                "commands": [
+                  {
+                    "command": "dance.seek.object",
+                    "args": [
+                      {
+                        "input": "(?#noescape)`(?#inner)(?#noescape)`"
+                      }
+                    ]
+                  },
+                  {
+                    "command": "dance.selections.reduce.edges"
+                  },
+                  {
+                    "command": "dance.edit.delete"
+                  },
+                  {
+                    "command": "dance.selections.clear.secondary"
+                  }
+                ]
+              },
+              "text": "grave quote string"
             }
           }
         },
@@ -1345,6 +2120,30 @@
         "when": "editorTextFocus && dance.mode == 'helix/normal'",
         "title": "Select to character (excluded)",
         "command": "dance.seek"
+      },
+      {
+        "key": "]",
+        "when": "editorTextFocus && dance.mode == 'helix/normal'",
+        "title": "Select to whole object end",
+        "command": "dance.seek.askObject.end"
+      },
+      {
+        "key": "]",
+        "when": "editorTextFocus && dance.mode == 'helix/select'",
+        "title": "Select to whole object end",
+        "command": "dance.seek.askObject.end"
+      },
+      {
+        "key": "[",
+        "when": "editorTextFocus && dance.mode == 'helix/normal'",
+        "title": "Select to whole object start",
+        "command": "dance.seek.askObject.start"
+      },
+      {
+        "key": "[",
+        "when": "editorTextFocus && dance.mode == 'helix/select'",
+        "title": "Select to whole object start",
+        "command": "dance.seek.askObject.start"
       },
       {
         "key": "Shift+T",

--- a/src/api/data/commands.yaml
+++ b/src/api/data/commands.yaml
@@ -1073,6 +1073,7 @@ seek.askObject.end:
   keys:
     qwerty: |-
       `]` (kakoune: normal)
+      `]` (helix: normal; helix: select)
 
 seek.askObject.end.extend:
   title:
@@ -1151,6 +1152,7 @@ seek.askObject.start:
   keys:
     qwerty: |-
       `[` (kakoune: normal)
+      `[` (helix: normal; helix: select)
 
 seek.askObject.start.extend:
   title:
@@ -1347,18 +1349,18 @@ seek.object:
 
       #### Variants
 
-      | Title                        | Identifier                     | Keybinding                                       | Command                                                                                       |
-      | ---------------------------- | ------------------------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-      | Select whole object          | `askObject`                    | `a-a` (kakoune: normal), `a-a` (kakoune: insert) | `[".openMenu", { menu: "object",                          title: "Select whole object..." }]` |
-      | Select inner object          | `askObject.inner`              | `a-i` (kakoune: normal), `a-i` (kakoune: insert) | `[".openMenu", { menu: "object", pass: [{ inner: true }], title: "Select inner object..." }]` |
-      | Select to whole object start | `askObject.start`              | `[` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "start"                  }] }]` |
-      | Extend to whole object start | `askObject.start.extend`       | `{` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "start", shift: "extend" }] }]` |
-      | Select to inner object start | `askObject.inner.start`        | `a-[` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start"                  }] }]` |
-      | Extend to inner object start | `askObject.inner.start.extend` | `a-{` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start", shift: "extend" }] }]` |
-      | Select to whole object end   | `askObject.end`                | `]` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "end"                    }] }]` |
-      | Extend to whole object end   | `askObject.end.extend`         | `}` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "end"  , shift: "extend" }] }]` |
-      | Select to inner object end   | `askObject.inner.end`          | `a-]` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"                    }] }]` |
-      | Extend to inner object end   | `askObject.inner.end.extend`   | `a-}` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"  , shift: "extend" }] }]` |
+      | Title                        | Identifier                     | Keybinding                                                | Command                                                                                       |
+      | ---------------------------- | ------------------------------ | --------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+      | Select whole object          | `askObject`                    | `a-a` (kakoune: normal), `a-a` (kakoune: insert)          | `[".openMenu", { menu: "object",                          title: "Select whole object..." }]` |
+      | Select inner object          | `askObject.inner`              | `a-i` (kakoune: normal), `a-i` (kakoune: insert)          | `[".openMenu", { menu: "object", pass: [{ inner: true }], title: "Select inner object..." }]` |
+      | Select to whole object start | `askObject.start`              | `[` (kakoune: normal), `[` (helix: normal; helix: select) | `[".openMenu", { menu: "object", pass: [{              where: "start"                  }] }]` |
+      | Extend to whole object start | `askObject.start.extend`       | `{` (kakoune: normal)                                     | `[".openMenu", { menu: "object", pass: [{              where: "start", shift: "extend" }] }]` |
+      | Select to inner object start | `askObject.inner.start`        | `a-[` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start"                  }] }]` |
+      | Extend to inner object start | `askObject.inner.start.extend` | `a-{` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start", shift: "extend" }] }]` |
+      | Select to whole object end   | `askObject.end`                | `]` (kakoune: normal), `]` (helix: normal; helix: select) | `[".openMenu", { menu: "object", pass: [{              where: "end"                    }] }]` |
+      | Extend to whole object end   | `askObject.end.extend`         | `}` (kakoune: normal)                                     | `[".openMenu", { menu: "object", pass: [{              where: "end"  , shift: "extend" }] }]` |
+      | Select to inner object end   | `askObject.inner.end`          | `a-]` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"                    }] }]` |
+      | Extend to inner object end   | `askObject.inner.end.extend`   | `a-}` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"  , shift: "extend" }] }]` |
 
 seek.syntax.child.experimental:
   title:

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -105,14 +105,14 @@ selections are empty</td><td></td></tr>
 <tr><td><a href="#seek.object"><code>seek.object</code></a></td><td>Select object</td><td></td></tr>
 <tr><td><a href="#seek.seek"><code>seek.seek</code></a></td><td>Select to character (excluded)</td><td><code>T</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="./seek.ts#L290"><code>seek.askObject</code></a></td><td>Select whole object</td><td><code>Alt+A</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>Alt+A</code> (<code>editorTextFocus && dance.mode == 'insert'</code>)</td></tr>
-<tr><td><a href="./seek.ts#L296"><code>seek.askObject.end</code></a></td><td>Select to whole object end</td><td><code>]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
+<tr><td><a href="./seek.ts#L296"><code>seek.askObject.end</code></a></td><td>Select to whole object end</td><td><code>]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>]</code> (<code>editorTextFocus && dance.mode == 'select'</code>)</td></tr>
 <tr><td><a href="./seek.ts#L297"><code>seek.askObject.end.extend</code></a></td><td>Extend to whole object end</td><td><code>Shift+]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="./seek.ts#L291"><code>seek.askObject.inner</code></a></td><td>Select inner object</td><td><code>Alt+I</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>Alt+I</code> (<code>editorTextFocus && dance.mode == 'insert'</code>)</td></tr>
 <tr><td><a href="./seek.ts#L298"><code>seek.askObject.inner.end</code></a></td><td>Select to inner object end</td><td><code>Alt+]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="./seek.ts#L299"><code>seek.askObject.inner.end.extend</code></a></td><td>Extend to inner object end</td><td><code>Shift+Alt+]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="./seek.ts#L294"><code>seek.askObject.inner.start</code></a></td><td>Select to inner object start</td><td><code>Alt+[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="./seek.ts#L295"><code>seek.askObject.inner.start.extend</code></a></td><td>Extend to inner object start</td><td><code>Shift+Alt+[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
-<tr><td><a href="./seek.ts#L292"><code>seek.askObject.start</code></a></td><td>Select to whole object start</td><td><code>[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
+<tr><td><a href="./seek.ts#L292"><code>seek.askObject.start</code></a></td><td>Select to whole object start</td><td><code>[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>[</code> (<code>editorTextFocus && dance.mode == 'select'</code>)</td></tr>
 <tr><td><a href="./seek.ts#L293"><code>seek.askObject.start.extend</code></a></td><td>Extend to whole object start</td><td><code>Shift+[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="./seek.ts#L33"><code>seek.backward</code></a></td><td>Select to character (excluded, backward)</td><td><code>Alt+T</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>Shift+T</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="./seek.ts#L98"><code>seek.enclosing.backward</code></a></td><td>Select to previous enclosing character</td><td><code>Alt+M</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
@@ -1137,18 +1137,18 @@ Select object.
 
 #### Variants
 
-| Title                        | Identifier                     | Keybinding                                       | Command                                                                                       |
-| ---------------------------- | ------------------------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| Select whole object          | `askObject`                    | `a-a` (kakoune: normal), `a-a` (kakoune: insert) | `[".openMenu", { menu: "object",                          title: "Select whole object..." }]` |
-| Select inner object          | `askObject.inner`              | `a-i` (kakoune: normal), `a-i` (kakoune: insert) | `[".openMenu", { menu: "object", pass: [{ inner: true }], title: "Select inner object..." }]` |
-| Select to whole object start | `askObject.start`              | `[` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "start"                  }] }]` |
-| Extend to whole object start | `askObject.start.extend`       | `{` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "start", shift: "extend" }] }]` |
-| Select to inner object start | `askObject.inner.start`        | `a-[` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start"                  }] }]` |
-| Extend to inner object start | `askObject.inner.start.extend` | `a-{` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start", shift: "extend" }] }]` |
-| Select to whole object end   | `askObject.end`                | `]` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "end"                    }] }]` |
-| Extend to whole object end   | `askObject.end.extend`         | `}` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "end"  , shift: "extend" }] }]` |
-| Select to inner object end   | `askObject.inner.end`          | `a-]` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"                    }] }]` |
-| Extend to inner object end   | `askObject.inner.end.extend`   | `a-}` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"  , shift: "extend" }] }]` |
+| Title                        | Identifier                     | Keybinding                                                | Command                                                                                       |
+| ---------------------------- | ------------------------------ | --------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Select whole object          | `askObject`                    | `a-a` (kakoune: normal), `a-a` (kakoune: insert)          | `[".openMenu", { menu: "object",                          title: "Select whole object..." }]` |
+| Select inner object          | `askObject.inner`              | `a-i` (kakoune: normal), `a-i` (kakoune: insert)          | `[".openMenu", { menu: "object", pass: [{ inner: true }], title: "Select inner object..." }]` |
+| Select to whole object start | `askObject.start`              | `[` (kakoune: normal), `[` (helix: normal; helix: select) | `[".openMenu", { menu: "object", pass: [{              where: "start"                  }] }]` |
+| Extend to whole object start | `askObject.start.extend`       | `{` (kakoune: normal)                                     | `[".openMenu", { menu: "object", pass: [{              where: "start", shift: "extend" }] }]` |
+| Select to inner object start | `askObject.inner.start`        | `a-[` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start"                  }] }]` |
+| Extend to inner object start | `askObject.inner.start.extend` | `a-{` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start", shift: "extend" }] }]` |
+| Select to whole object end   | `askObject.end`                | `]` (kakoune: normal), `]` (helix: normal; helix: select) | `[".openMenu", { menu: "object", pass: [{              where: "end"                    }] }]` |
+| Extend to whole object end   | `askObject.end.extend`         | `}` (kakoune: normal)                                     | `[".openMenu", { menu: "object", pass: [{              where: "end"  , shift: "extend" }] }]` |
+| Select to inner object end   | `askObject.inner.end`          | `a-]` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"                    }] }]` |
+| Extend to inner object end   | `askObject.inner.end.extend`   | `a-}` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"  , shift: "extend" }] }]` |
 
 This command:
 - takes an argument `inner` of type `boolean`.

--- a/src/commands/layouts/azerty.fr.md
+++ b/src/commands/layouts/azerty.fr.md
@@ -90,14 +90,14 @@ selections are empty</td><td></td></tr>
 <tr><td><a href="#seek.object"><code>seek.object</code></a></td><td>Select object</td><td></td></tr>
 <tr><td><a href="#seek.seek"><code>seek.seek</code></a></td><td>Select to character (excluded)</td><td><code>T</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L290"><code>seek.askObject</code></a></td><td>Select whole object</td><td><code>Alt+A</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>Alt+A</code> (<code>editorTextFocus && dance.mode == 'insert'</code>)</td></tr>
-<tr><td><a href="../seek.ts#L296"><code>seek.askObject.end</code></a></td><td>Select to whole object end</td><td><code>]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
+<tr><td><a href="../seek.ts#L296"><code>seek.askObject.end</code></a></td><td>Select to whole object end</td><td><code>]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>]</code> (<code>editorTextFocus && dance.mode == 'select'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L297"><code>seek.askObject.end.extend</code></a></td><td>Extend to whole object end</td><td><code>Shift+]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L291"><code>seek.askObject.inner</code></a></td><td>Select inner object</td><td><code>Alt+I</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>Alt+I</code> (<code>editorTextFocus && dance.mode == 'insert'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L298"><code>seek.askObject.inner.end</code></a></td><td>Select to inner object end</td><td><code>Alt+]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L299"><code>seek.askObject.inner.end.extend</code></a></td><td>Extend to inner object end</td><td><code>Shift+Alt+]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L294"><code>seek.askObject.inner.start</code></a></td><td>Select to inner object start</td><td><code>Alt+[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L295"><code>seek.askObject.inner.start.extend</code></a></td><td>Extend to inner object start</td><td><code>Shift+Alt+[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
-<tr><td><a href="../seek.ts#L292"><code>seek.askObject.start</code></a></td><td>Select to whole object start</td><td><code>[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
+<tr><td><a href="../seek.ts#L292"><code>seek.askObject.start</code></a></td><td>Select to whole object start</td><td><code>[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>[</code> (<code>editorTextFocus && dance.mode == 'select'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L293"><code>seek.askObject.start.extend</code></a></td><td>Extend to whole object start</td><td><code>Shift+[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L33"><code>seek.backward</code></a></td><td>Select to character (excluded, backward)</td><td><code>Alt+T</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>Shift+T</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L98"><code>seek.enclosing.backward</code></a></td><td>Select to previous enclosing character</td><td><code>Alt+M</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
@@ -1122,18 +1122,18 @@ Select object.
 
 #### Variants
 
-| Title                        | Identifier                     | Keybinding                                       | Command                                                                                       |
-| ---------------------------- | ------------------------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| Select whole object          | `askObject`                    | `a-a` (kakoune: normal), `a-a` (kakoune: insert) | `[".openMenu", { menu: "object",                          title: "Select whole object..." }]` |
-| Select inner object          | `askObject.inner`              | `a-i` (kakoune: normal), `a-i` (kakoune: insert) | `[".openMenu", { menu: "object", pass: [{ inner: true }], title: "Select inner object..." }]` |
-| Select to whole object start | `askObject.start`              | `[` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "start"                  }] }]` |
-| Extend to whole object start | `askObject.start.extend`       | `{` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "start", shift: "extend" }] }]` |
-| Select to inner object start | `askObject.inner.start`        | `a-[` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start"                  }] }]` |
-| Extend to inner object start | `askObject.inner.start.extend` | `a-{` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start", shift: "extend" }] }]` |
-| Select to whole object end   | `askObject.end`                | `]` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "end"                    }] }]` |
-| Extend to whole object end   | `askObject.end.extend`         | `}` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "end"  , shift: "extend" }] }]` |
-| Select to inner object end   | `askObject.inner.end`          | `a-]` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"                    }] }]` |
-| Extend to inner object end   | `askObject.inner.end.extend`   | `a-}` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"  , shift: "extend" }] }]` |
+| Title                        | Identifier                     | Keybinding                                                | Command                                                                                       |
+| ---------------------------- | ------------------------------ | --------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Select whole object          | `askObject`                    | `a-a` (kakoune: normal), `a-a` (kakoune: insert)          | `[".openMenu", { menu: "object",                          title: "Select whole object..." }]` |
+| Select inner object          | `askObject.inner`              | `a-i` (kakoune: normal), `a-i` (kakoune: insert)          | `[".openMenu", { menu: "object", pass: [{ inner: true }], title: "Select inner object..." }]` |
+| Select to whole object start | `askObject.start`              | `[` (kakoune: normal), `[` (helix: normal; helix: select) | `[".openMenu", { menu: "object", pass: [{              where: "start"                  }] }]` |
+| Extend to whole object start | `askObject.start.extend`       | `{` (kakoune: normal)                                     | `[".openMenu", { menu: "object", pass: [{              where: "start", shift: "extend" }] }]` |
+| Select to inner object start | `askObject.inner.start`        | `a-[` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start"                  }] }]` |
+| Extend to inner object start | `askObject.inner.start.extend` | `a-{` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start", shift: "extend" }] }]` |
+| Select to whole object end   | `askObject.end`                | `]` (kakoune: normal), `]` (helix: normal; helix: select) | `[".openMenu", { menu: "object", pass: [{              where: "end"                    }] }]` |
+| Extend to whole object end   | `askObject.end.extend`         | `}` (kakoune: normal)                                     | `[".openMenu", { menu: "object", pass: [{              where: "end"  , shift: "extend" }] }]` |
+| Select to inner object end   | `askObject.inner.end`          | `a-]` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"                    }] }]` |
+| Extend to inner object end   | `askObject.inner.end.extend`   | `a-}` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"  , shift: "extend" }] }]` |
 
 This command:
 - takes an argument `inner` of type `boolean`.

--- a/src/commands/layouts/qwerty.md
+++ b/src/commands/layouts/qwerty.md
@@ -90,14 +90,14 @@ selections are empty</td><td></td></tr>
 <tr><td><a href="#seek.object"><code>seek.object</code></a></td><td>Select object</td><td></td></tr>
 <tr><td><a href="#seek.seek"><code>seek.seek</code></a></td><td>Select to character (excluded)</td><td><code>T</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L290"><code>seek.askObject</code></a></td><td>Select whole object</td><td><code>Alt+A</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>Alt+A</code> (<code>editorTextFocus && dance.mode == 'insert'</code>)</td></tr>
-<tr><td><a href="../seek.ts#L296"><code>seek.askObject.end</code></a></td><td>Select to whole object end</td><td><code>]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
+<tr><td><a href="../seek.ts#L296"><code>seek.askObject.end</code></a></td><td>Select to whole object end</td><td><code>]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>]</code> (<code>editorTextFocus && dance.mode == 'select'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L297"><code>seek.askObject.end.extend</code></a></td><td>Extend to whole object end</td><td><code>Shift+]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L291"><code>seek.askObject.inner</code></a></td><td>Select inner object</td><td><code>Alt+I</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>Alt+I</code> (<code>editorTextFocus && dance.mode == 'insert'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L298"><code>seek.askObject.inner.end</code></a></td><td>Select to inner object end</td><td><code>Alt+]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L299"><code>seek.askObject.inner.end.extend</code></a></td><td>Extend to inner object end</td><td><code>Shift+Alt+]</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L294"><code>seek.askObject.inner.start</code></a></td><td>Select to inner object start</td><td><code>Alt+[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L295"><code>seek.askObject.inner.start.extend</code></a></td><td>Extend to inner object start</td><td><code>Shift+Alt+[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
-<tr><td><a href="../seek.ts#L292"><code>seek.askObject.start</code></a></td><td>Select to whole object start</td><td><code>[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
+<tr><td><a href="../seek.ts#L292"><code>seek.askObject.start</code></a></td><td>Select to whole object start</td><td><code>[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>[</code> (<code>editorTextFocus && dance.mode == 'select'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L293"><code>seek.askObject.start.extend</code></a></td><td>Extend to whole object start</td><td><code>Shift+[</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L33"><code>seek.backward</code></a></td><td>Select to character (excluded, backward)</td><td><code>Alt+T</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)<code>Shift+T</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
 <tr><td><a href="../seek.ts#L98"><code>seek.enclosing.backward</code></a></td><td>Select to previous enclosing character</td><td><code>Alt+M</code> (<code>editorTextFocus && dance.mode == 'normal'</code>)</td></tr>
@@ -1122,18 +1122,18 @@ Select object.
 
 #### Variants
 
-| Title                        | Identifier                     | Keybinding                                       | Command                                                                                       |
-| ---------------------------- | ------------------------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| Select whole object          | `askObject`                    | `a-a` (kakoune: normal), `a-a` (kakoune: insert) | `[".openMenu", { menu: "object",                          title: "Select whole object..." }]` |
-| Select inner object          | `askObject.inner`              | `a-i` (kakoune: normal), `a-i` (kakoune: insert) | `[".openMenu", { menu: "object", pass: [{ inner: true }], title: "Select inner object..." }]` |
-| Select to whole object start | `askObject.start`              | `[` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "start"                  }] }]` |
-| Extend to whole object start | `askObject.start.extend`       | `{` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "start", shift: "extend" }] }]` |
-| Select to inner object start | `askObject.inner.start`        | `a-[` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start"                  }] }]` |
-| Extend to inner object start | `askObject.inner.start.extend` | `a-{` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start", shift: "extend" }] }]` |
-| Select to whole object end   | `askObject.end`                | `]` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "end"                    }] }]` |
-| Extend to whole object end   | `askObject.end.extend`         | `}` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "end"  , shift: "extend" }] }]` |
-| Select to inner object end   | `askObject.inner.end`          | `a-]` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"                    }] }]` |
-| Extend to inner object end   | `askObject.inner.end.extend`   | `a-}` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"  , shift: "extend" }] }]` |
+| Title                        | Identifier                     | Keybinding                                                | Command                                                                                       |
+| ---------------------------- | ------------------------------ | --------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Select whole object          | `askObject`                    | `a-a` (kakoune: normal), `a-a` (kakoune: insert)          | `[".openMenu", { menu: "object",                          title: "Select whole object..." }]` |
+| Select inner object          | `askObject.inner`              | `a-i` (kakoune: normal), `a-i` (kakoune: insert)          | `[".openMenu", { menu: "object", pass: [{ inner: true }], title: "Select inner object..." }]` |
+| Select to whole object start | `askObject.start`              | `[` (kakoune: normal), `[` (helix: normal; helix: select) | `[".openMenu", { menu: "object", pass: [{              where: "start"                  }] }]` |
+| Extend to whole object start | `askObject.start.extend`       | `{` (kakoune: normal)                                     | `[".openMenu", { menu: "object", pass: [{              where: "start", shift: "extend" }] }]` |
+| Select to inner object start | `askObject.inner.start`        | `a-[` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start"                  }] }]` |
+| Extend to inner object start | `askObject.inner.start.extend` | `a-{` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start", shift: "extend" }] }]` |
+| Select to whole object end   | `askObject.end`                | `]` (kakoune: normal), `]` (helix: normal; helix: select) | `[".openMenu", { menu: "object", pass: [{              where: "end"                    }] }]` |
+| Extend to whole object end   | `askObject.end.extend`         | `}` (kakoune: normal)                                     | `[".openMenu", { menu: "object", pass: [{              where: "end"  , shift: "extend" }] }]` |
+| Select to inner object end   | `askObject.inner.end`          | `a-]` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"                    }] }]` |
+| Extend to inner object end   | `askObject.inner.end.extend`   | `a-}` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"  , shift: "extend" }] }]` |
 
 This command:
 - takes an argument `inner` of type `boolean`.

--- a/src/commands/seek.ts
+++ b/src/commands/seek.ts
@@ -285,18 +285,18 @@ let lastObjectInput: string | undefined;
  *
  * #### Variants
  *
- * | Title                        | Identifier                     | Keybinding                                       | Command                                                                                       |
- * | ---------------------------- | ------------------------------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------- |
- * | Select whole object          | `askObject`                    | `a-a` (kakoune: normal), `a-a` (kakoune: insert) | `[".openMenu", { menu: "object",                          title: "Select whole object..." }]` |
- * | Select inner object          | `askObject.inner`              | `a-i` (kakoune: normal), `a-i` (kakoune: insert) | `[".openMenu", { menu: "object", pass: [{ inner: true }], title: "Select inner object..." }]` |
- * | Select to whole object start | `askObject.start`              | `[` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "start"                  }] }]` |
- * | Extend to whole object start | `askObject.start.extend`       | `{` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "start", shift: "extend" }] }]` |
- * | Select to inner object start | `askObject.inner.start`        | `a-[` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start"                  }] }]` |
- * | Extend to inner object start | `askObject.inner.start.extend` | `a-{` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start", shift: "extend" }] }]` |
- * | Select to whole object end   | `askObject.end`                | `]` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "end"                    }] }]` |
- * | Extend to whole object end   | `askObject.end.extend`         | `}` (kakoune: normal)                            | `[".openMenu", { menu: "object", pass: [{              where: "end"  , shift: "extend" }] }]` |
- * | Select to inner object end   | `askObject.inner.end`          | `a-]` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"                    }] }]` |
- * | Extend to inner object end   | `askObject.inner.end.extend`   | `a-}` (kakoune: normal)                          | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"  , shift: "extend" }] }]` |
+ * | Title                        | Identifier                     | Keybinding                                                | Command                                                                                       |
+ * | ---------------------------- | ------------------------------ | --------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+ * | Select whole object          | `askObject`                    | `a-a` (kakoune: normal), `a-a` (kakoune: insert)          | `[".openMenu", { menu: "object",                          title: "Select whole object..." }]` |
+ * | Select inner object          | `askObject.inner`              | `a-i` (kakoune: normal), `a-i` (kakoune: insert)          | `[".openMenu", { menu: "object", pass: [{ inner: true }], title: "Select inner object..." }]` |
+ * | Select to whole object start | `askObject.start`              | `[` (kakoune: normal), `[` (helix: normal; helix: select) | `[".openMenu", { menu: "object", pass: [{              where: "start"                  }] }]` |
+ * | Extend to whole object start | `askObject.start.extend`       | `{` (kakoune: normal)                                     | `[".openMenu", { menu: "object", pass: [{              where: "start", shift: "extend" }] }]` |
+ * | Select to inner object start | `askObject.inner.start`        | `a-[` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start"                  }] }]` |
+ * | Extend to inner object start | `askObject.inner.start.extend` | `a-{` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "start", shift: "extend" }] }]` |
+ * | Select to whole object end   | `askObject.end`                | `]` (kakoune: normal), `]` (helix: normal; helix: select) | `[".openMenu", { menu: "object", pass: [{              where: "end"                    }] }]` |
+ * | Extend to whole object end   | `askObject.end.extend`         | `}` (kakoune: normal)                                     | `[".openMenu", { menu: "object", pass: [{              where: "end"  , shift: "extend" }] }]` |
+ * | Select to inner object end   | `askObject.inner.end`          | `a-]` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"                    }] }]` |
+ * | Extend to inner object end   | `askObject.inner.end.extend`   | `a-}` (kakoune: normal)                                   | `[".openMenu", { menu: "object", pass: [{ inner: true, where: "end"  , shift: "extend" }] }]` |
  */
 export async function object(
   _: Context,


### PR DESCRIPTION
This pull request adds `ms`, `mr`, and `md` to the Helix keymap, along with the following fixes:
* Line numbers are now absolute in `helix/insert` and `helix/select`, relative in `helix/normal`.
* Unimpaired mappings `[` and `]` are added back to the Helix keymap, they were missing for some reason.

All these keybinds use existing Dance commands, the only limitation being that `md` will replace the nearest pair instead of asking for the pair to delete. It may be more efficient to implement these as commands, though I understand that the core is still supposed to be Kakoune-based.