### PR TITLE
misc: update actions, grant permission to write tag in publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: yarn
@@ -32,8 +32,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
Internally, I also changed a couple of settings:
- The `GITHUB_TOKEN` now only has read permissions by default.
- First-time contributors (who are not new in GitHub) can run workflows.