### PR TITLE
feat: make `dance.openMenu` retain count/register state

### DIFF
--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -860,7 +860,7 @@ This command:
 
 <a name="openMenu" />
 
-### [`openMenu`](./misc.ts#L309-L331)
+### [`openMenu`](./misc.ts#L309-L332)
 
 Open menu.
 
@@ -884,7 +884,7 @@ This command:
 
 <a name="changeInput" />
 
-### [`changeInput`](./misc.ts#L372-L386)
+### [`changeInput`](./misc.ts#L373-L387)
 
 Change current input.
 
@@ -901,7 +901,7 @@ This command:
 
 <a name="ifEmpty" />
 
-### [`ifEmpty`](./misc.ts#L396-L407)
+### [`ifEmpty`](./misc.ts#L397-L408)
 
 Executes one of the specified commands depending on whether the current
 selections are empty.

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -54,6 +54,10 @@ export class CommandDescriptor<Flags extends CommandDescriptor.Flags = CommandDe
     return (this.flags & CommandDescriptor.Flags.DoNotReplay) === 0;
   }
 
+  public get shouldResetEphemeralState() {
+    return (this.flags & CommandDescriptor.Flags.KeepEphemeralState) === 0;
+  }
+
   public constructor(
     /**
      * The unique identifier of the command.
@@ -104,8 +108,10 @@ export class CommandDescriptor<Flags extends CommandDescriptor.Flags = CommandDe
       context.doNotRecord();
     }
 
-    extension.currentCount = 0;
-    extension.currentRegister = undefined;
+    if (this.shouldResetEphemeralState) {
+      extension.currentCount = 0;
+      extension.currentRegister = undefined;
+    }
 
     let result: unknown;
 
@@ -168,6 +174,9 @@ export /* enum */ namespace CommandDescriptor {
 
     /** The command should not be replayed in macros and repeats. */
     DoNotReplay = 0b0010,
+
+    /** The command should not reset ephemeral state (selected count/register). */
+    KeepEphemeralState = 0b0100,
   }
 }
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -54,8 +54,8 @@ export class CommandDescriptor<Flags extends CommandDescriptor.Flags = CommandDe
     return (this.flags & CommandDescriptor.Flags.DoNotReplay) === 0;
   }
 
-  public get shouldResetEphemeralState() {
-    return (this.flags & CommandDescriptor.Flags.KeepEphemeralState) === 0;
+  public get shouldResetContext() {
+    return (this.flags & CommandDescriptor.Flags.KeepContext) === 0;
   }
 
   public constructor(
@@ -108,7 +108,7 @@ export class CommandDescriptor<Flags extends CommandDescriptor.Flags = CommandDe
       context.doNotRecord();
     }
 
-    if (this.shouldResetEphemeralState) {
+    if (this.shouldResetContext) {
       extension.currentCount = 0;
       extension.currentRegister = undefined;
     }
@@ -175,8 +175,8 @@ export /* enum */ namespace CommandDescriptor {
     /** The command should not be replayed in macros and repeats. */
     DoNotReplay = 0b0010,
 
-    /** The command should not reset ephemeral state (selected count/register). */
-    KeepEphemeralState = 0b0100,
+    /** The command should not reset context (selected count/register). */
+    KeepContext = 0b0100,
   }
 }
 

--- a/src/commands/layouts/azerty.fr.md
+++ b/src/commands/layouts/azerty.fr.md
@@ -845,7 +845,7 @@ This command:
 
 <a name="openMenu" />
 
-### [`openMenu`](../misc.ts#L309-L331)
+### [`openMenu`](../misc.ts#L309-L332)
 
 Open menu.
 
@@ -869,7 +869,7 @@ This command:
 
 <a name="changeInput" />
 
-### [`changeInput`](../misc.ts#L372-L386)
+### [`changeInput`](../misc.ts#L373-L387)
 
 Change current input.
 
@@ -886,7 +886,7 @@ This command:
 
 <a name="ifEmpty" />
 
-### [`ifEmpty`](../misc.ts#L396-L407)
+### [`ifEmpty`](../misc.ts#L397-L408)
 
 Executes one of the specified commands depending on whether the current
 selections are empty.

--- a/src/commands/layouts/qwerty.md
+++ b/src/commands/layouts/qwerty.md
@@ -845,7 +845,7 @@ This command:
 
 <a name="openMenu" />
 
-### [`openMenu`](../misc.ts#L309-L331)
+### [`openMenu`](../misc.ts#L309-L332)
 
 Open menu.
 
@@ -869,7 +869,7 @@ This command:
 
 <a name="changeInput" />
 
-### [`changeInput`](../misc.ts#L372-L386)
+### [`changeInput`](../misc.ts#L373-L387)
 
 Change current input.
 
@@ -886,7 +886,7 @@ This command:
 
 <a name="ifEmpty" />
 
-### [`ifEmpty`](../misc.ts#L396-L407)
+### [`ifEmpty`](../misc.ts#L397-L408)
 
 Executes one of the specified commands depending on whether the current
 selections are empty.

--- a/src/commands/load-all.build.ts
+++ b/src/commands/load-all.build.ts
@@ -226,8 +226,8 @@ function determineFunctionFlags(f: Builder.ParsedFunction) {
     flags.push("DoNotReplay");
   }
 
-  if ("keepephemeral" in f.properties) {
-    flags.push("KeepEphemeralState");
+  if ("keepcontext" in f.properties) {
+    flags.push("KeepContext");
   }
 
   if (flags.length === 0) {

--- a/src/commands/load-all.build.ts
+++ b/src/commands/load-all.build.ts
@@ -226,6 +226,10 @@ function determineFunctionFlags(f: Builder.ParsedFunction) {
     flags.push("DoNotReplay");
   }
 
+  if ("keepephemeral" in f.properties) {
+    flags.push("KeepEphemeralState");
+  }
+
   if (flags.length === 0) {
     return "CommandDescriptor.Flags.None";
   }

--- a/src/commands/load-all.ts
+++ b/src/commands/load-all.ts
@@ -444,7 +444,7 @@ export const commands: Commands = function () {
     "dance.openMenu": new CommandDescriptor(
       "dance.openMenu",
       (_, argument) => _.runAsync(async (_) => await openMenu(_, getInputOr("menu", argument), argument["prefix"], argument["pass"], argument["locked"], argument["delay"], argument["title"])),
-      CommandDescriptor.Flags.DoNotReplay | CommandDescriptor.Flags.KeepEphemeralState,
+      CommandDescriptor.Flags.DoNotReplay | CommandDescriptor.Flags.KeepContext,
     ),
     "dance.run": new CommandDescriptor(
       "dance.run",

--- a/src/commands/load-all.ts
+++ b/src/commands/load-all.ts
@@ -444,7 +444,7 @@ export const commands: Commands = function () {
     "dance.openMenu": new CommandDescriptor(
       "dance.openMenu",
       (_, argument) => _.runAsync(async (_) => await openMenu(_, getInputOr("menu", argument), argument["prefix"], argument["pass"], argument["locked"], argument["delay"], argument["title"])),
-      CommandDescriptor.Flags.DoNotReplay,
+      CommandDescriptor.Flags.DoNotReplay | CommandDescriptor.Flags.KeepEphemeralState,
     ),
     "dance.run": new CommandDescriptor(
       "dance.run",

--- a/src/commands/misc.ts
+++ b/src/commands/misc.ts
@@ -318,6 +318,7 @@ const menuHistory: string[] = [];
  * like `jj`.
  *
  * @noreplay
+ * @keepephemeral
  */
 export async function openMenu(
   _: Context.WithoutActiveEditor,

--- a/src/commands/misc.ts
+++ b/src/commands/misc.ts
@@ -318,7 +318,7 @@ const menuHistory: string[] = [];
  * like `jj`.
  *
  * @noreplay
- * @keepephemeral
+ * @keepcontext
  */
 export async function openMenu(
   _: Context.WithoutActiveEditor,

--- a/test/suite/utils.ts
+++ b/test/suite/utils.ts
@@ -396,6 +396,7 @@ export class ExpectedDocument {
             end = editor.document.lineAt(editor.document.lineCount - 1).rangeIncludingLineBreak.end;
 
       builder.replace(new vscode.Range(start, end), this.text);
+      builder.setEndOfLine(vscode.EndOfLine.LF);
     });
 
     if (this.selections.length > 0) {


### PR DESCRIPTION
This is #375 with an additional commit which renames `keepephemeral` to `keepcontext` as it [reads better to me](https://github.com/71/dance/pull/375#discussion_r2105713966).

**NOTE**: Does not work yet; the context is kept even after the command selected by the menu runs, which is unexpected. I tried to instead forward args to the menu using `...`, but it doesn't work with inner objects, so more work is needed there.