### PR TITLE
misc: bump Helix version to 0.1.1

### DIFF
--- a/extensions/helix/package.build.ts
+++ b/extensions/helix/package.build.ts
@@ -5,7 +5,7 @@ import { Builder, generateIgnoredKeybinds } from "../../meta";
 import * as fs from "fs/promises";
 import { extensionId } from "../../src/utils/constants";
 
-const version = "0.1.0",
+const version = "0.1.1",
       preRelease = 1;
 
 export const pkg = (modules: Builder.ParsedModule[]) => ({

--- a/extensions/helix/package.json
+++ b/extensions/helix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dance-helix",
   "description": "Helix keybindings for Dance",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "ISC",
   "extensionDependencies": [
     "gregoire.dance"
@@ -38,8 +38,8 @@
   "scripts": {
     "package": "vsce package --allow-star-activation",
     "publish": "vsce publish --allow-star-activation",
-    "package:pre": "vsce package --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json 0.1.0001",
-    "publish:pre": "vsce publish --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json 0.1.0001"
+    "package:pre": "vsce package --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json 0.1.1001",
+    "publish:pre": "vsce publish --allow-star-activation --pre-release --no-git-tag-version --no-update-package-json 0.1.1001"
   },
   "devDependencies": {
     "@vscode/vsce": "^3.3.2"


### PR DESCRIPTION
Generating a pre-release which looks like 0.1.0001 broke VS Code:

> ScanningExtension: Cannot read the extension from
> $HOME/.vscode/extensions/gregoire.dance-helix-0.1.0001