### PR TITLE
Preserve selection direction with search-next

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -259,5 +259,5 @@ function nextImpl(
   }
 
   return Selections.fromLength(
-    searchResult[0], searchResult[1][0].length, /* isReversed= */ false, document);
+    searchResult[0], searchResult[1][0].length, selection.isReversed, document);
 }

--- a/test/suite/commands/search-next.md
+++ b/test/suite/commands/search-next.md
@@ -158,6 +158,33 @@ pear pineapple apple
 kiwi orange kiwi
 ```
 
+### 1 search-apple inverted-next
+[up](#1-search-apple)
+
+- .selections.changeDirection
+- .search.next
+
+```
+apple pineapple pear
+pear pineapple apple
+         |^^^^ 0
+kiwi orange kiwi
+```
+
+### 1 search-apple inverted-next-add
+[up](#1-search-apple)
+
+- .selections.changeDirection
+- .search.next.add
+
+```
+apple pineapple pear
+          |^^^^ 1
+pear pineapple apple
+         |^^^^ 0
+kiwi orange kiwi
+```
+
 # 2
 
 ```

--- a/test/suite/commands/search-next.test.ts
+++ b/test/suite/commands/search-next.test.ts
@@ -257,6 +257,51 @@ suite("./test/suite/commands/search-next.md", function () {
     `);
   });
 
+  test("1 > search-apple > inverted-next", async function () {
+    // Set-up document to be in expected initial state.
+    await ExpectedDocument.apply(editor, 6, String.raw`
+      apple pineapple pear
+                ^^^^^ 0
+      pear pineapple apple
+      kiwi orange kiwi
+    `);
+
+    // Perform all operations.
+    await executeCommand("dance.selections.changeDirection");
+    await executeCommand("dance.search.next");
+
+    // Ensure document is as expected.
+    ExpectedDocument.assertEquals(editor, "./test/suite/commands/search-next.md:161:1", 6, String.raw`
+      apple pineapple pear
+      pear pineapple apple
+               |^^^^ 0
+      kiwi orange kiwi
+    `);
+  });
+
+  test("1 > search-apple > inverted-next-add", async function () {
+    // Set-up document to be in expected initial state.
+    await ExpectedDocument.apply(editor, 6, String.raw`
+      apple pineapple pear
+                ^^^^^ 0
+      pear pineapple apple
+      kiwi orange kiwi
+    `);
+
+    // Perform all operations.
+    await executeCommand("dance.selections.changeDirection");
+    await executeCommand("dance.search.next.add");
+
+    // Ensure document is as expected.
+    ExpectedDocument.assertEquals(editor, "./test/suite/commands/search-next.md:174:1", 6, String.raw`
+      apple pineapple pear
+                |^^^^ 1
+      pear pineapple apple
+               |^^^^ 0
+      kiwi orange kiwi
+    `);
+  });
+
   test("2 > search-next-add", async function () {
     // Set-up document to be in expected initial state.
     await ExpectedDocument.apply(editor, 6, String.raw`
@@ -275,7 +320,7 @@ suite("./test/suite/commands/search-next.md", function () {
     await executeCommand("dance.search.next.add");
 
     // Ensure document is as expected.
-    ExpectedDocument.assertEquals(editor, "./test/suite/commands/search-next.md:174:1", 6, String.raw`
+    ExpectedDocument.assertEquals(editor, "./test/suite/commands/search-next.md:201:1", 6, String.raw`
       foo
       foo
       ^^^ 1
@@ -306,7 +351,7 @@ suite("./test/suite/commands/search-next.md", function () {
     await executeCommand("dance.search.next");
 
     // Ensure document is as expected.
-    ExpectedDocument.assertEquals(editor, "./test/suite/commands/search-next.md:192:1", 6, String.raw`
+    ExpectedDocument.assertEquals(editor, "./test/suite/commands/search-next.md:219:1", 6, String.raw`
       foo
       foo
       ^^^ 1
@@ -337,7 +382,7 @@ suite("./test/suite/commands/search-next.md", function () {
     await executeCommand("dance.search.next");
 
     // Ensure document is as expected.
-    ExpectedDocument.assertEquals(editor, "./test/suite/commands/search-next.md:209:1", 6, String.raw`
+    ExpectedDocument.assertEquals(editor, "./test/suite/commands/search-next.md:236:1", 6, String.raw`
       foo
       foo
       ^^^ 1


### PR DESCRIPTION
When using `n` to select the next occurrence, give the new selection the same direction as the previous main selection. This matches the behaviour from kakoune and helix.

Fix: #360 
(At least, I assume that this is what #360 is referring to.)