### PR TITLE
Add paragraph to helix bracket menus

### DIFF
--- a/extensions/helix/package.build.ts
+++ b/extensions/helix/package.build.ts
@@ -280,6 +280,7 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
           items: {
             "d": { text: "Goto previous diagnostic", command: "editor.action.marker.prevInFiles" },
             "g": { text: "Goto previous change", command: "workbench.action.editor.previousChange" },
+            "p": { text: "Goto previous paragraph", command: "dance.seek.object", args: [{ "input": "(?#predefined=paragraph)", "where": "start", "inner": false }] },
             " ": { text: "Add newline above", command: "dance.edit.newLine.above" },
           },
         },
@@ -289,6 +290,7 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
           items: {
             "d": { text: "Goto next diagnostic", command: "editor.action.marker.nextInFiles" },
             "g": { text: "Goto next change", command: "workbench.action.editor.nextChange" },
+            "p": { text: "Goto next paragraph", command: "dance.seek.object", args: [{ "input": "(?#predefined=paragraph)", "where": "end" }] },
             " ": { text: "Add newline below", command: "dance.edit.newLine.below" },
           },
         },

--- a/extensions/helix/package.json
+++ b/extensions/helix/package.json
@@ -1207,6 +1207,17 @@
               "text": "Goto previous change",
               "command": "workbench.action.editor.previousChange"
             },
+            "p": {
+              "text": "Goto previous paragraph",
+              "command": "dance.seek.object",
+              "args": [
+                {
+                  "input": "(?#predefined=paragraph)",
+                  "where": "start",
+                  "inner": false
+                }
+              ]
+            },
             " ": {
               "text": "Add newline above",
               "command": "dance.edit.newLine.above"
@@ -1223,6 +1234,16 @@
             "g": {
               "text": "Goto next change",
               "command": "workbench.action.editor.nextChange"
+            },
+            "p": {
+              "text": "Goto next paragraph",
+              "command": "dance.seek.object",
+              "args": [
+                {
+                  "input": "(?#predefined=paragraph)",
+                  "where": "end"
+                }
+              ]
             },
             " ": {
               "text": "Add newline below",
@@ -1612,7 +1633,26 @@
         "title": "Left bracket",
         "command": "dance.openMenu",
         "args": {
-          "menu": "leftBracket"
+          "menu": "leftBracket",
+          "pass": [
+            {
+              "shift": "select"
+            }
+          ]
+        }
+      },
+      {
+        "key": "[",
+        "when": "editorTextFocus && dance.mode == 'helix/select'",
+        "title": "Left bracket",
+        "command": "dance.openMenu",
+        "args": {
+          "menu": "leftBracket",
+          "pass": [
+            {
+              "shift": "extend"
+            }
+          ]
         }
       },
       {
@@ -1621,7 +1661,26 @@
         "title": "Right bracket",
         "command": "dance.openMenu",
         "args": {
-          "menu": "rightBracket"
+          "menu": "rightBracket",
+          "pass": [
+            {
+              "shift": "select"
+            }
+          ]
+        }
+      },
+      {
+        "key": "]",
+        "when": "editorTextFocus && dance.mode == 'helix/select'",
+        "title": "Right bracket",
+        "command": "dance.openMenu",
+        "args": {
+          "menu": "rightBracket",
+          "pass": [
+            {
+              "shift": "extend"
+            }
+          ]
         }
       },
       {

--- a/meta.ts
+++ b/meta.ts
@@ -738,6 +738,8 @@ async function main() {
 
   if (buildErrors.length > 0) {
     console.error(buildErrors);
+
+    success = false;
   }
 
   if (ensureUpToDate) {

--- a/src/api/data/commands.yaml
+++ b/src/api/data/commands.yaml
@@ -783,10 +783,12 @@ openMenu:
 
       #### Predefined menus
 
-      | Title         | Keybinding          | Command                                   |
-      | ------------- | ------------------- | ----------------------------------------- |
-      | Left bracket  | `[` (helix: normal) | `[".openMenu", { menu: "leftBracket" }]`  |
-      | Right bracket | `]` (helix: normal) | `[".openMenu", { menu: "rightBracket" }]` |
+      | Title         | Keybinding          | Command                                                                  |
+      | ------------- | ------------------- | ------------------------------------------------------------------------ |
+      | Left bracket  | `[` (helix: normal) | `[".openMenu", { menu: "leftBracket",  pass: [ { shift: "select" } ] }]` |
+      | Left bracket  | `[` (helix: select) | `[".openMenu", { menu: "leftBracket",  pass: [ { shift: "extend" } ] }]` |
+      | Right bracket | `]` (helix: normal) | `[".openMenu", { menu: "rightBracket", pass: [ { shift: "select" } ] }]` |
+      | Right bracket | `]` (helix: select) | `[".openMenu", { menu: "rightBracket", pass: [ { shift: "extend" } ] }]` |
 
 run:
   title:
@@ -2799,7 +2801,17 @@ anonymous:
       en: Left bracket
 
     commands: |-
-      [".openMenu", { menu: "leftBracket" }]
+      [".openMenu", { menu: "leftBracket", pass: [ { shift: "extend" } ] }]
+
+    keys:
+      qwerty: |-
+        `[` (helix: select)
+
+  - title:
+      en: Left bracket
+
+    commands: |-
+      [".openMenu", { menu: "leftBracket", pass: [ { shift: "select" } ] }]
 
     keys:
       qwerty: |-
@@ -2829,7 +2841,17 @@ anonymous:
       en: Right bracket
 
     commands: |-
-      [".openMenu", { menu: "rightBracket" }]
+      [".openMenu", { menu: "rightBracket", pass: [ { shift: "extend" } ] }]
+
+    keys:
+      qwerty: |-
+        `]` (helix: select)
+
+  - title:
+      en: Right bracket
+
+    commands: |-
+      [".openMenu", { menu: "rightBracket", pass: [ { shift: "select" } ] }]
 
     keys:
       qwerty: |-

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -862,7 +862,7 @@ This command:
 
 <a name="openMenu" />
 
-### [`openMenu`](./misc.ts#L309-L338)
+### [`openMenu`](./misc.ts#L309-L340)
 
 Open menu.
 
@@ -876,10 +876,12 @@ like `jj`.
 
 #### Predefined menus
 
-| Title         | Keybinding          | Command                                   |
-| ------------- | ------------------- | ----------------------------------------- |
-| Left bracket  | `[` (helix: normal) | `[".openMenu", { menu: "leftBracket" }]`  |
-| Right bracket | `]` (helix: normal) | `[".openMenu", { menu: "rightBracket" }]` |
+| Title         | Keybinding          | Command                                                                  |
+| ------------- | ------------------- | ------------------------------------------------------------------------ |
+| Left bracket  | `[` (helix: normal) | `[".openMenu", { menu: "leftBracket",  pass: [ { shift: "select" } ] }]` |
+| Left bracket  | `[` (helix: select) | `[".openMenu", { menu: "leftBracket",  pass: [ { shift: "extend" } ] }]` |
+| Right bracket | `]` (helix: normal) | `[".openMenu", { menu: "rightBracket", pass: [ { shift: "select" } ] }]` |
+| Right bracket | `]` (helix: select) | `[".openMenu", { menu: "rightBracket", pass: [ { shift: "extend" } ] }]` |
 
 
 This command:
@@ -893,7 +895,7 @@ This command:
 
 <a name="changeInput" />
 
-### [`changeInput`](./misc.ts#L379-L393)
+### [`changeInput`](./misc.ts#L381-L395)
 
 Change current input.
 
@@ -910,7 +912,7 @@ This command:
 
 <a name="ifEmpty" />
 
-### [`ifEmpty`](./misc.ts#L403-L414)
+### [`ifEmpty`](./misc.ts#L405-L416)
 
 Executes one of the specified commands depending on whether the current
 selections are empty.

--- a/src/commands/layouts/azerty.fr.md
+++ b/src/commands/layouts/azerty.fr.md
@@ -847,7 +847,7 @@ This command:
 
 <a name="openMenu" />
 
-### [`openMenu`](../misc.ts#L309-L338)
+### [`openMenu`](../misc.ts#L309-L340)
 
 Open menu.
 
@@ -861,10 +861,12 @@ like `jj`.
 
 #### Predefined menus
 
-| Title         | Keybinding          | Command                                   |
-| ------------- | ------------------- | ----------------------------------------- |
-| Left bracket  | `[` (helix: normal) | `[".openMenu", { menu: "leftBracket" }]`  |
-| Right bracket | `]` (helix: normal) | `[".openMenu", { menu: "rightBracket" }]` |
+| Title         | Keybinding          | Command                                                                  |
+| ------------- | ------------------- | ------------------------------------------------------------------------ |
+| Left bracket  | `[` (helix: normal) | `[".openMenu", { menu: "leftBracket",  pass: [ { shift: "select" } ] }]` |
+| Left bracket  | `[` (helix: select) | `[".openMenu", { menu: "leftBracket",  pass: [ { shift: "extend" } ] }]` |
+| Right bracket | `]` (helix: normal) | `[".openMenu", { menu: "rightBracket", pass: [ { shift: "select" } ] }]` |
+| Right bracket | `]` (helix: select) | `[".openMenu", { menu: "rightBracket", pass: [ { shift: "extend" } ] }]` |
 
 
 This command:
@@ -878,7 +880,7 @@ This command:
 
 <a name="changeInput" />
 
-### [`changeInput`](../misc.ts#L379-L393)
+### [`changeInput`](../misc.ts#L381-L395)
 
 Change current input.
 
@@ -895,7 +897,7 @@ This command:
 
 <a name="ifEmpty" />
 
-### [`ifEmpty`](../misc.ts#L403-L414)
+### [`ifEmpty`](../misc.ts#L405-L416)
 
 Executes one of the specified commands depending on whether the current
 selections are empty.

--- a/src/commands/layouts/qwerty.md
+++ b/src/commands/layouts/qwerty.md
@@ -847,7 +847,7 @@ This command:
 
 <a name="openMenu" />
 
-### [`openMenu`](../misc.ts#L309-L338)
+### [`openMenu`](../misc.ts#L309-L340)
 
 Open menu.
 
@@ -861,10 +861,12 @@ like `jj`.
 
 #### Predefined menus
 
-| Title         | Keybinding          | Command                                   |
-| ------------- | ------------------- | ----------------------------------------- |
-| Left bracket  | `[` (helix: normal) | `[".openMenu", { menu: "leftBracket" }]`  |
-| Right bracket | `]` (helix: normal) | `[".openMenu", { menu: "rightBracket" }]` |
+| Title         | Keybinding          | Command                                                                  |
+| ------------- | ------------------- | ------------------------------------------------------------------------ |
+| Left bracket  | `[` (helix: normal) | `[".openMenu", { menu: "leftBracket",  pass: [ { shift: "select" } ] }]` |
+| Left bracket  | `[` (helix: select) | `[".openMenu", { menu: "leftBracket",  pass: [ { shift: "extend" } ] }]` |
+| Right bracket | `]` (helix: normal) | `[".openMenu", { menu: "rightBracket", pass: [ { shift: "select" } ] }]` |
+| Right bracket | `]` (helix: select) | `[".openMenu", { menu: "rightBracket", pass: [ { shift: "extend" } ] }]` |
 
 
 This command:
@@ -878,7 +880,7 @@ This command:
 
 <a name="changeInput" />
 
-### [`changeInput`](../misc.ts#L379-L393)
+### [`changeInput`](../misc.ts#L381-L395)
 
 Change current input.
 
@@ -895,7 +897,7 @@ This command:
 
 <a name="ifEmpty" />
 
-### [`ifEmpty`](../misc.ts#L403-L414)
+### [`ifEmpty`](../misc.ts#L405-L416)
 
 Executes one of the specified commands depending on whether the current
 selections are empty.

--- a/src/commands/misc.ts
+++ b/src/commands/misc.ts
@@ -319,10 +319,12 @@ const menuHistory: string[] = [];
  *
  * #### Predefined menus
  *
- * | Title         | Keybinding          | Command                                   |
- * | ------------- | ------------------- | ----------------------------------------- |
- * | Left bracket  | `[` (helix: normal) | `[".openMenu", { menu: "leftBracket" }]`  |
- * | Right bracket | `]` (helix: normal) | `[".openMenu", { menu: "rightBracket" }]` |
+ * | Title         | Keybinding          | Command                                                                  |
+ * | ------------- | ------------------- | ------------------------------------------------------------------------ |
+ * | Left bracket  | `[` (helix: normal) | `[".openMenu", { menu: "leftBracket",  pass: [ { shift: "select" } ] }]` |
+ * | Left bracket  | `[` (helix: select) | `[".openMenu", { menu: "leftBracket",  pass: [ { shift: "extend" } ] }]` |
+ * | Right bracket | `]` (helix: normal) | `[".openMenu", { menu: "rightBracket", pass: [ { shift: "select" } ] }]` |
+ * | Right bracket | `]` (helix: select) | `[".openMenu", { menu: "rightBracket", pass: [ { shift: "extend" } ] }]` |
  *
  * @noreplay
  */


### PR DESCRIPTION
Add 'Goto next paragraph' and 'Goto previous paragraph' to helix, under the keybinds `[p` and `]p`.