### PR TITLE
fix minor memory leaks

### DIFF
--- a/src/state/editors.ts
+++ b/src/state/editors.ts
@@ -687,7 +687,7 @@ export class Editors implements vscode.Disposable {
       state.dispose();
     }
 
-    this._lastRemovedEditorStates.length === 0;
+    this._lastRemovedEditorStates.length = 0;
 
     // Dispose of fallback editor, if any.
     const fallback = this._fallbacks.get(document);

--- a/src/state/extension.ts
+++ b/src/state/extension.ts
@@ -204,7 +204,6 @@ export class Extension implements vscode.Disposable {
       },
       true,
     );
-
   }
 
   /**
@@ -219,6 +218,24 @@ export class Extension implements vscode.Disposable {
     assert(this._autoDisposables.size === 0);
 
     this.statusBar.dispose();
+
+    // Clear configuration handlers.
+    this._configurationChangeHandlers.clear();
+
+    // Dispose of all subscriptions.
+    for (const subscription of this._subscriptions) {
+      subscription.dispose();
+    }
+    this._subscriptions.length = 0;
+
+    // Dispose of core components.
+    this.editors.dispose();
+    this.recorder.dispose();
+    this.modes.dispose();
+    this.registers.dispose();
+
+    // Dismiss error message, if any.
+    this.dismissErrorMessage();
   }
 
   /**

--- a/src/state/modes.ts
+++ b/src/state/modes.ts
@@ -552,7 +552,7 @@ export declare namespace Mode {
 /**
  * The set of all modes.
  */
-export class Modes implements Iterable<Mode> {
+export class Modes implements Iterable<Mode>, vscode.Disposable {
   private readonly _vscodeModeDefaults: Mode.Configuration = {
     cursorStyle: "line",
     inheritFrom: null,
@@ -579,6 +579,13 @@ export class Modes implements Iterable<Mode> {
 
     this._vscodeMode.apply(this._vscodeModeDefaults, new SettingsValidator());
     this._observePreferences(extension);
+  }
+
+  public dispose(): void {
+    for (const mode of this._modes.values()) {
+      mode.dispose();
+    }
+    this._modes.clear();
   }
 
   /**

--- a/src/state/recorder.ts
+++ b/src/state/recorder.ts
@@ -204,7 +204,11 @@ export class Recorder implements vscode.Disposable {
    * call.
    */
   public cursorFromEnd() {
-    return new Cursor(this, this._previousBuffers.length, this._buffer.length - 1);
+    return new Cursor(
+      this,
+      this._previousBuffers.length,
+      this._buffer.length === 0 ? 0 : this._buffer.length - 1,
+    );
   }
 
   /**


### PR DESCRIPTION
These are pretty minor:

- The one in `editors.ts` only leaks memory until a new editor is
  opened.

- The other one only happens when Dance is disabled.

Also fixes iteration of recorder when reaching the start of a buffer.

Co-authored-by: Enrico Lumetti <enrico.lumetti@gmail.com>