### PR TITLE
Add Helix Go to Implementation

### DIFF
--- a/extensions/helix/package.build.ts
+++ b/extensions/helix/package.build.ts
@@ -261,6 +261,7 @@ export const pkg = (modules: Builder.ParsedModule[]) => ({
             "l": { text: "to line end", command: "dance.select.lineEnd" },
             "s": { text: "to first non-blank in line", command: "dance.select.lineStart", args: [{ skipBlank: true }] },
             "d": { text: "to definition", command: "editor.action.revealDefinition" },
+            "i": { text: "to implementation", command: "editor.action.goToImplementation" },
             "r": { text: "to references", command: "editor.action.goToReferences" },
             "j": { text: "to last line", command: "dance.select.lastLine" },
             "t": { text: "to window top", command: "dance.select.firstVisibleLine" },

--- a/extensions/helix/package.json
+++ b/extensions/helix/package.json
@@ -1145,6 +1145,10 @@
               "text": "to definition",
               "command": "editor.action.revealDefinition"
             },
+            "i": {
+              "text": "to implementation",
+              "command": "editor.action.goToImplementation"
+            },
             "r": {
               "text": "to references",
               "command": "editor.action.goToReferences"


### PR DESCRIPTION
Added it after `to definition` and before `to reference`. In helix itself, it's after `Goto references`. What do you prefer?