### PR TITLE
feat(helix): implement helix xc behavior implements #376

### DIFF
--- a/extensions/helix/package.json
+++ b/extensions/helix/package.json
@@ -1591,13 +1591,51 @@
         "key": "C",
         "when": "editorTextFocus && dance.mode == 'helix/normal'",
         "title": "Copy, delete and switch to Insert",
-        "command": "dance.edit.yank-delete-insert"
+        "command": "dance.run",
+        "args": {
+          "code": [
+            "const editor = vscode.window.activeTextEditor;",
+            "if (!editor) return;",
+            "const onlyWholeLines = editor.selections.length > 0 && editor.selections.every(sel => {",
+            "  if (sel.isEmpty) return false;",
+            "  let start = sel.start;",
+            "  let end = sel.end;",
+            "  if (start.character !== 0) return false;",
+            "  const endLineLength = editor.document.lineAt(end.line).text.length;",
+            "  return end.character === (sel.isReversed ? 0:endLineLength) && end.line >= start.line;",
+            "});",
+            "if (onlyWholeLines) {",
+            "  await vscode.commands.executeCommand('dance.run', { commands: [['.edit.yank-delete'],['.edit.newLine.above', { shift: 'select' }], ['.modes.insert.before']] });",
+            "} else {",
+            "  await vscode.commands.executeCommand('dance.run', { commands: [['.edit.yank-delete-insert']] });",
+            "}"
+          ]
+        }
       },
       {
         "key": "C",
         "when": "editorTextFocus && dance.mode == 'helix/select'",
         "title": "Copy, delete and switch to Insert",
-        "command": "dance.edit.yank-delete-insert"
+        "command": "dance.run",
+        "args": {
+          "code": [
+            "const editor = vscode.window.activeTextEditor;",
+            "if (!editor) return;",
+            "const onlyWholeLines = editor.selections.length > 0 && editor.selections.every(sel => {",
+            "  if (sel.isEmpty) return false;",
+            "  let start = sel.start;",
+            "  let end = sel.end;",
+            "  if (start.character !== 0) return false;",
+            "  const endLineLength = editor.document.lineAt(end.line).text.length;",
+            "  return end.character === (sel.isReversed ? 0:endLineLength) && end.line >= start.line;",
+            "});",
+            "if (onlyWholeLines) {",
+            "  await vscode.commands.executeCommand('dance.run', { commands: [['.edit.yank-delete'],['.edit.newLine.above', { shift: 'select' }], ['.modes.insert.before']] });",
+            "} else {",
+            "  await vscode.commands.executeCommand('dance.run', { commands: [['.edit.yank-delete-insert']] });",
+            "}"
+          ]
+        }
       },
       {
         "key": "Shift+R",


### PR DESCRIPTION
Implements #376

When `c`ing (change_selection or yank-delete-insert) selections consisting of whole lines, Helix inserts a new line.
This implementation mimics it accurately.
It works for multi selections and reverse selections.
